### PR TITLE
Improve displaying long expenses

### DIFF
--- a/app/src/main/java/de/dbauer/expensetracker/ui/RecurringExpenseOverview.kt
+++ b/app/src/main/java/de/dbauer/expensetracker/ui/RecurringExpenseOverview.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -166,6 +167,7 @@ private fun RecurringExpense(
                                 "${recurringExpenseData.everyXRecurrence} " +
                                 stringResource(id = recurringExpenseData.recurrence.stringRes),
                         style = MaterialTheme.typography.bodyLarge,
+                        textAlign = TextAlign.End,
                     )
                 }
             }
@@ -212,6 +214,15 @@ private fun RecurringExpenseOverviewPreview() {
                             monthlyPrice = 7.95f,
                             everyXRecurrence = 1,
                             recurrence = Recurrence.Monthly,
+                        ),
+                        RecurringExpenseData(
+                            id = 3,
+                            name = "Yearly Test Subscription",
+                            description = "Test Description with another very long name",
+                            price = 72f,
+                            monthlyPrice = 6f,
+                            everyXRecurrence = 1,
+                            recurrence = Recurrence.Yearly,
                         ),
                     ),
                 onItemClicked = {},

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -21,10 +21,10 @@
     <string name="edit_expense_name_placeholder">z.B. Netflix</string>
     <string name="edit_expense_price">Preis</string>
     <string name="edit_expense_recurrence">Abrechnungszeitraum</string>
-    <string name="edit_expense_recurrence_day">Tag(e)</string>
-    <string name="edit_expense_recurrence_week">Woche(n)</string>
-    <string name="edit_expense_recurrence_month">Monat(e)</string>
-    <string name="edit_expense_recurrence_year">Jahr(e)</string>
+    <string name="edit_expense_recurrence_day">T</string>
+    <string name="edit_expense_recurrence_week">W</string>
+    <string name="edit_expense_recurrence_month">M</string>
+    <string name="edit_expense_recurrence_year">J</string>
 
     <string name="settings_title">Einstellungen</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,10 +23,10 @@
     <string name="edit_expense_name_placeholder">e.g. Netflix</string>
     <string name="edit_expense_price">Price</string>
     <string name="edit_expense_recurrence">Recurrence</string>
-    <string name="edit_expense_recurrence_day">Day(s)</string>
-    <string name="edit_expense_recurrence_week">Week(s)</string>
-    <string name="edit_expense_recurrence_month">Month(s)</string>
-    <string name="edit_expense_recurrence_year">Year(s)</string>
+    <string name="edit_expense_recurrence_day">D</string>
+    <string name="edit_expense_recurrence_week">W</string>
+    <string name="edit_expense_recurrence_month">M</string>
+    <string name="edit_expense_recurrence_year">Y</string>
 
     <string name="settings_title">Settings</string>
 


### PR DESCRIPTION
When expenses have a non monthly recurrence and have a long name the price substring was cutting the long name even though that could be prevented.