### PR TITLE
Decrease app size in release significantly by enabling minify and resource shrinking

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,7 +39,8 @@ android {
 
     buildTypes {
         named("release") {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",


### PR DESCRIPTION
This reduced the release build of the app from 11.6MB to 2.1MB.