### PR TITLE
Add option to define a color for an expense

### DIFF
--- a/app/schemas/de.dbauer.expensetracker.viewmodel.database.RecurringExpenseDatabase/4.json
+++ b/app/schemas/de.dbauer.expensetracker.viewmodel.database.RecurringExpenseDatabase/4.json
@@ -1,0 +1,76 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "282372e1874072a008d7ff5985cf0929",
+    "entities": [
+      {
+        "tableName": "recurring_expenses",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT, `description` TEXT, `price` REAL, `everyXRecurrence` INTEGER, `recurrence` INTEGER, `firstPayment` INTEGER, `color` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "price",
+            "columnName": "price",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "everyXRecurrence",
+            "columnName": "everyXRecurrence",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "recurrence",
+            "columnName": "recurrence",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "firstPayment",
+            "columnName": "firstPayment",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '282372e1874072a008d7ff5985cf0929')"
+    ]
+  }
+}

--- a/app/src/main/java/de/dbauer/expensetracker/Extensions.kt
+++ b/app/src/main/java/de/dbauer/expensetracker/Extensions.kt
@@ -1,5 +1,6 @@
 package de.dbauer.expensetracker
 
+import androidx.compose.ui.Modifier
 import java.text.NumberFormat
 import java.util.Calendar
 import java.util.zip.ZipEntry
@@ -40,4 +41,15 @@ fun Calendar.isSameDay(other: Calendar): Boolean {
     return this.get(Calendar.YEAR) == other.get(Calendar.YEAR) &&
         this.get(Calendar.MONTH) == other.get(Calendar.MONTH) &&
         this.get(Calendar.DAY_OF_MONTH) == other.get(Calendar.DAY_OF_MONTH)
+}
+
+fun Modifier.conditional(
+    condition: Boolean,
+    modifier: Modifier.() -> Modifier,
+): Modifier {
+    return if (condition) {
+        then(modifier(Modifier))
+    } else {
+        this
+    }
 }

--- a/app/src/main/java/de/dbauer/expensetracker/MainActivity.kt
+++ b/app/src/main/java/de/dbauer/expensetracker/MainActivity.kt
@@ -49,6 +49,7 @@ import de.dbauer.expensetracker.data.Recurrence
 import de.dbauer.expensetracker.data.RecurringExpenseData
 import de.dbauer.expensetracker.ui.RecurringExpenseOverview
 import de.dbauer.expensetracker.ui.SettingsScreen
+import de.dbauer.expensetracker.ui.customizations.ExpenseColor
 import de.dbauer.expensetracker.ui.editexpense.EditRecurringExpense
 import de.dbauer.expensetracker.ui.theme.ExpenseTrackerTheme
 import de.dbauer.expensetracker.ui.upcomingexpenses.UpcomingPaymentsScreen
@@ -349,6 +350,7 @@ private fun MainActivityContentPreview() {
                     everyXRecurrence = 1,
                     recurrence = Recurrence.Monthly,
                     0L,
+                    ExpenseColor.Dynamic,
                 ),
                 RecurringExpenseData(
                     id = 1,
@@ -359,6 +361,7 @@ private fun MainActivityContentPreview() {
                     everyXRecurrence = 1,
                     recurrence = Recurrence.Monthly,
                     1L,
+                    ExpenseColor.Red,
                 ),
                 RecurringExpenseData(
                     id = 2,
@@ -369,6 +372,7 @@ private fun MainActivityContentPreview() {
                     everyXRecurrence = 1,
                     recurrence = Recurrence.Monthly,
                     2L,
+                    ExpenseColor.Blue,
                 ),
             ),
         onRecurringExpenseAdded = {},

--- a/app/src/main/java/de/dbauer/expensetracker/data/RecurringExpenseData.kt
+++ b/app/src/main/java/de/dbauer/expensetracker/data/RecurringExpenseData.kt
@@ -1,7 +1,9 @@
 package de.dbauer.expensetracker.data
 
 import androidx.annotation.StringRes
+import androidx.compose.runtime.Immutable
 import de.dbauer.expensetracker.R
+import de.dbauer.expensetracker.ui.customizations.ExpenseColor
 
 enum class Recurrence(
     @StringRes val fullStringRes: Int,
@@ -13,6 +15,7 @@ enum class Recurrence(
     Yearly(R.string.edit_expense_recurrence_year, R.string.edit_expense_recurrence_year_short),
 }
 
+@Immutable
 data class RecurringExpenseData(
     val id: Int,
     val name: String,
@@ -22,4 +25,5 @@ data class RecurringExpenseData(
     val everyXRecurrence: Int,
     val recurrence: Recurrence,
     val firstPayment: Long,
+    val color: ExpenseColor,
 )

--- a/app/src/main/java/de/dbauer/expensetracker/data/UpcomingPaymentData.kt
+++ b/app/src/main/java/de/dbauer/expensetracker/data/UpcomingPaymentData.kt
@@ -1,9 +1,12 @@
 package de.dbauer.expensetracker.data
 
+import de.dbauer.expensetracker.ui.customizations.ExpenseColor
+
 data class UpcomingPaymentData(
     val id: Int,
     val name: String,
     val price: Float,
     val nextPaymentRemainingDays: Int,
     val nextPaymentDate: String,
+    val color: ExpenseColor,
 )

--- a/app/src/main/java/de/dbauer/expensetracker/ui/RecurringExpenseOverview.kt
+++ b/app/src/main/java/de/dbauer/expensetracker/ui/RecurringExpenseOverview.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -27,6 +28,7 @@ import de.dbauer.expensetracker.R
 import de.dbauer.expensetracker.data.Recurrence
 import de.dbauer.expensetracker.data.RecurringExpenseData
 import de.dbauer.expensetracker.toCurrencyString
+import de.dbauer.expensetracker.ui.customizations.ExpenseColor
 import de.dbauer.expensetracker.ui.theme.ExpenseTrackerTheme
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
@@ -127,6 +129,7 @@ private fun RecurringExpense(
 ) {
     Card(
         modifier = modifier.clickable { onItemClicked() },
+        colors = CardDefaults.cardColors(containerColor = recurringExpenseData.color.getColor()),
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
@@ -195,6 +198,7 @@ private fun RecurringExpenseOverviewPreview() {
                             everyXRecurrence = 1,
                             recurrence = Recurrence.Monthly,
                             0L,
+                            ExpenseColor.Dynamic,
                         ),
                         RecurringExpenseData(
                             id = 1,
@@ -207,6 +211,7 @@ private fun RecurringExpenseOverviewPreview() {
                             everyXRecurrence = 1,
                             recurrence = Recurrence.Monthly,
                             1L,
+                            ExpenseColor.Orange,
                         ),
                         RecurringExpenseData(
                             id = 2,
@@ -217,6 +222,7 @@ private fun RecurringExpenseOverviewPreview() {
                             everyXRecurrence = 1,
                             recurrence = Recurrence.Monthly,
                             2L,
+                            ExpenseColor.Turquoise,
                         ),
                         RecurringExpenseData(
                             id = 3,
@@ -227,6 +233,7 @@ private fun RecurringExpenseOverviewPreview() {
                             everyXRecurrence = 1,
                             recurrence = Recurrence.Yearly,
                             3L,
+                            ExpenseColor.Dynamic,
                         ),
                     ),
                 onItemClicked = {},

--- a/app/src/main/java/de/dbauer/expensetracker/ui/customizations/ExpenseColor.kt
+++ b/app/src/main/java/de/dbauer/expensetracker/ui/customizations/ExpenseColor.kt
@@ -1,0 +1,64 @@
+package de.dbauer.expensetracker.ui.customizations
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
+import de.dbauer.expensetracker.R
+
+enum class ExpenseColor(private val value: Int) {
+    Dynamic(1),
+    Red(2),
+    Orange(3),
+    Yellow(4),
+    Green(5),
+    Mint(6),
+    Turquoise(7),
+    Cyan(8),
+    Blue(9),
+    Purple(10),
+    Pink(11),
+    Maroon(12),
+    ;
+
+    @Composable
+    fun getColor(): Color {
+        return when (this) {
+            Dynamic -> MaterialTheme.colorScheme.surfaceVariant
+            Red -> colorResource(id = R.color.expense_predefined_red)
+            Orange -> colorResource(id = R.color.expense_predefined_orange)
+            Yellow -> colorResource(id = R.color.expense_predefined_yellow)
+            Green -> colorResource(id = R.color.expense_predefined_green)
+            Mint -> colorResource(id = R.color.expense_predefined_mint)
+            Turquoise -> colorResource(id = R.color.expense_predefined_turquoise)
+            Cyan -> colorResource(id = R.color.expense_predefined_cyan)
+            Blue -> colorResource(id = R.color.expense_predefined_blue)
+            Purple -> colorResource(id = R.color.expense_predefined_purple)
+            Pink -> colorResource(id = R.color.expense_predefined_pink)
+            Maroon -> colorResource(id = R.color.expense_predefined_maroon)
+        }
+    }
+
+    fun toInt(): Int {
+        return value
+    }
+
+    companion object {
+        fun fromInt(value: Int?): ExpenseColor {
+            return when (value) {
+                Dynamic.value -> Dynamic
+                Orange.value -> Orange
+                Yellow.value -> Yellow
+                Green.value -> Green
+                Mint.value -> Mint
+                Turquoise.value -> Turquoise
+                Cyan.value -> Cyan
+                Blue.value -> Blue
+                Purple.value -> Purple
+                Pink.value -> Pink
+                Maroon.value -> Maroon
+                else -> Dynamic
+            }
+        }
+    }
+}

--- a/app/src/main/java/de/dbauer/expensetracker/ui/editexpense/ColorOption.kt
+++ b/app/src/main/java/de/dbauer/expensetracker/ui/editexpense/ColorOption.kt
@@ -1,0 +1,162 @@
+package de.dbauer.expensetracker.ui.editexpense
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import de.dbauer.expensetracker.R
+import de.dbauer.expensetracker.conditional
+import de.dbauer.expensetracker.ui.customizations.ExpenseColor
+import de.dbauer.expensetracker.ui.theme.ExpenseTrackerTheme
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+
+@Composable
+fun ColorOption(
+    expenseColor: ExpenseColor,
+    onExpenseColorSelected: (ExpenseColor) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var colorPickerOpen by rememberSaveable { mutableStateOf(false) }
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier =
+            modifier
+                .padding(vertical = 8.dp)
+                .clickable { colorPickerOpen = true },
+    ) {
+        Text(
+            text = stringResource(R.string.edit_expense_color),
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        Spacer(modifier = Modifier.weight(1f))
+        expenseColor.getColor().let {
+            Canvas(
+                modifier =
+                    Modifier
+                        .size(48.dp),
+                onDraw = {
+                    drawCircle(color = it)
+                },
+            )
+        }
+    }
+
+    if (colorPickerOpen) {
+        ColorPickerDialog(
+            predefinedColors = getAvailableColors(),
+            onDismiss = { colorPickerOpen = false },
+            currentlySelected = expenseColor,
+            onColorSelected = onExpenseColorSelected,
+        )
+    }
+}
+
+@Composable
+private fun ColorPickerDialog(
+    predefinedColors: ImmutableList<ExpenseColor>,
+    onDismiss: (() -> Unit),
+    currentlySelected: ExpenseColor,
+    onColorSelected: ((ExpenseColor) -> Unit),
+) {
+    val gridState = rememberLazyGridState()
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        text = {
+            LazyVerticalGrid(
+                columns = GridCells.Adaptive(48.dp),
+                state = gridState,
+            ) {
+                items(predefinedColors) { color ->
+                    val outlineColor = MaterialTheme.colorScheme.onSurface
+
+                    Canvas(
+                        modifier =
+                            Modifier
+                                .padding(16.dp)
+                                .clip(RoundedCornerShape(50))
+                                .conditional(currentlySelected == color) {
+                                    border(
+                                        width = 2.dp,
+                                        color = outlineColor,
+                                        shape = RoundedCornerShape(50),
+                                    )
+                                }
+                                .background(color.getColor())
+                                .requiredSize(48.dp)
+                                .clickable {
+                                    onColorSelected(color)
+                                    onDismiss()
+                                },
+                    ) {
+                    }
+                }
+            }
+        },
+        confirmButton = {},
+    )
+}
+
+@Composable
+private fun getAvailableColors(): ImmutableList<ExpenseColor> {
+    return ExpenseColor.entries.toImmutableList()
+}
+
+@PreviewLightDark
+@Composable
+private fun ColorOptionPreview() {
+    ExpenseTrackerTheme {
+        Surface(
+            color = MaterialTheme.colorScheme.background,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            ColorOption(
+                expenseColor = ExpenseColor.Red,
+                onExpenseColorSelected = {},
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ColorPickerDialogPreview() {
+    ExpenseTrackerTheme {
+        var selectedColor by remember { mutableStateOf(ExpenseColor.Green) }
+        ColorPickerDialog(
+            predefinedColors = getAvailableColors(),
+            onDismiss = {},
+            currentlySelected = selectedColor,
+            onColorSelected = { selectedColor = it },
+        )
+    }
+}

--- a/app/src/main/java/de/dbauer/expensetracker/ui/editexpense/EditRecurringExpenseSheet.kt
+++ b/app/src/main/java/de/dbauer/expensetracker/ui/editexpense/EditRecurringExpenseSheet.kt
@@ -34,13 +34,14 @@ import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import de.dbauer.expensetracker.R
 import de.dbauer.expensetracker.data.Recurrence
 import de.dbauer.expensetracker.data.RecurringExpenseData
 import de.dbauer.expensetracker.toFloatIgnoreSeparator
 import de.dbauer.expensetracker.toLocalString
+import de.dbauer.expensetracker.ui.customizations.ExpenseColor
 import de.dbauer.expensetracker.ui.theme.ExpenseTrackerTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -110,6 +111,9 @@ private fun EditRecurringExpenseInternal(
     var firstPaymentDate by rememberSaveable {
         mutableLongStateOf(currentData?.firstPayment ?: 0L)
     }
+    var expenseColor by rememberSaveable {
+        mutableStateOf(currentData?.color ?: ExpenseColor.Dynamic)
+    }
 
     val scrollState = rememberScrollState()
     val localFocusManager = LocalFocusManager.current
@@ -148,6 +152,10 @@ private fun EditRecurringExpenseInternal(
         FirstPaymentOption(
             date = firstPaymentDate,
             onDateSelected = { firstPaymentDate = it },
+        )
+        ColorOption(
+            expenseColor = expenseColor,
+            onExpenseColorSelected = { expenseColor = it },
         )
         Row(
             modifier =
@@ -189,6 +197,7 @@ private fun EditRecurringExpenseInternal(
                         everyXRecurrenceState,
                         selectedRecurrence,
                         firstPaymentDate,
+                        expenseColor,
                         onUpdateExpense,
                         currentData,
                     )
@@ -217,6 +226,7 @@ private fun onConfirmClicked(
     everyXRecurrenceState: TextFieldValue,
     selectedRecurrence: Recurrence,
     firstPayment: Long,
+    expenseColor: ExpenseColor,
     onUpdateExpense: (RecurringExpenseData) -> Unit,
     currentData: RecurringExpenseData?,
 ) {
@@ -247,6 +257,7 @@ private fun onConfirmClicked(
                 everyXRecurrence = everyXRecurrence.toIntOrNull() ?: 1,
                 recurrence = selectedRecurrence,
                 firstPayment = firstPayment,
+                color = expenseColor,
             ),
         )
     }
@@ -289,7 +300,7 @@ private fun isEveryXRecurrenceValid(everyXRecurrence: String): Boolean {
     return everyXRecurrence.isBlank() || everyXRecurrence.toIntOrNull() != null
 }
 
-@Preview
+@PreviewLightDark
 @Composable
 private fun EditRecurringExpensePreview() {
     ExpenseTrackerTheme {

--- a/app/src/main/java/de/dbauer/expensetracker/ui/upcomingexpenses/UpcomingPaymentsScreen.kt
+++ b/app/src/main/java/de/dbauer/expensetracker/ui/upcomingexpenses/UpcomingPaymentsScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.List
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -24,12 +25,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import de.dbauer.expensetracker.R
 import de.dbauer.expensetracker.data.RecurringExpenseData
 import de.dbauer.expensetracker.data.UpcomingPaymentData
 import de.dbauer.expensetracker.toCurrencyString
+import de.dbauer.expensetracker.ui.customizations.ExpenseColor
 import de.dbauer.expensetracker.ui.theme.ExpenseTrackerTheme
 import de.dbauer.expensetracker.viewmodel.UpcomingPaymentsViewModel
 import kotlinx.collections.immutable.ImmutableList
@@ -106,6 +108,7 @@ private fun UpcomingPayment(
 
     Card(
         modifier = modifier.clickable { onItemClicked() },
+        colors = CardDefaults.cardColors(containerColor = upcomingPaymentData.color.getColor()),
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
@@ -163,7 +166,7 @@ fun UpcomingPaymentsOverviewPlaceholder(modifier: Modifier = Modifier) {
     }
 }
 
-@Preview
+@PreviewLightDark
 @Composable
 private fun UpcomingPaymentsOverviewPreview() {
     val dateFormat = DateFormat.getDateInstance()
@@ -195,6 +198,7 @@ private fun UpcomingPaymentsOverviewPreview() {
                             price = 9.99f,
                             nextPaymentRemainingDays = nextPaymentDays1,
                             nextPaymentDate = nextPaymentDate1String,
+                            color = ExpenseColor.Dynamic,
                         ),
                         UpcomingPaymentData(
                             id = 1,
@@ -202,6 +206,7 @@ private fun UpcomingPaymentsOverviewPreview() {
                             price = 5f,
                             nextPaymentRemainingDays = nextPaymentDays2,
                             nextPaymentDate = nextPaymentDate2String,
+                            color = ExpenseColor.Green,
                         ),
                         UpcomingPaymentData(
                             id = 2,
@@ -209,6 +214,7 @@ private fun UpcomingPaymentsOverviewPreview() {
                             price = 7.95f,
                             nextPaymentRemainingDays = nextPaymentDays3,
                             nextPaymentDate = nextPaymentDate3String,
+                            color = ExpenseColor.Pink,
                         ),
                     ),
                 onItemClicked = {},
@@ -218,7 +224,7 @@ private fun UpcomingPaymentsOverviewPreview() {
     }
 }
 
-@Preview
+@PreviewLightDark
 @Composable
 private fun UpcomingPaymentsOverviewPlaceholderPreview() {
     ExpenseTrackerTheme {

--- a/app/src/main/java/de/dbauer/expensetracker/viewmodel/RecurringExpenseViewModel.kt
+++ b/app/src/main/java/de/dbauer/expensetracker/viewmodel/RecurringExpenseViewModel.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.viewmodel.viewModelFactory
 import de.dbauer.expensetracker.data.Recurrence
 import de.dbauer.expensetracker.data.RecurringExpenseData
 import de.dbauer.expensetracker.toCurrencyString
+import de.dbauer.expensetracker.ui.customizations.ExpenseColor
 import de.dbauer.expensetracker.viewmodel.database.ExpenseRepository
 import de.dbauer.expensetracker.viewmodel.database.RecurrenceDatabase
 import de.dbauer.expensetracker.viewmodel.database.RecurringExpense
@@ -56,6 +57,7 @@ class RecurringExpenseViewModel(
                     everyXRecurrence = recurringExpense.everyXRecurrence,
                     recurrence = getRecurrenceIntFromUIRecurrence(recurringExpense.recurrence),
                     firstPayment = recurringExpense.firstPayment,
+                    color = recurringExpense.color.toInt(),
                 ),
             )
         }
@@ -72,6 +74,7 @@ class RecurringExpenseViewModel(
                     everyXRecurrence = recurringExpense.everyXRecurrence,
                     recurrence = getRecurrenceIntFromUIRecurrence(recurringExpense.recurrence),
                     firstPayment = recurringExpense.firstPayment,
+                    color = recurringExpense.color.toInt(),
                 ),
             )
         }
@@ -88,6 +91,7 @@ class RecurringExpenseViewModel(
                     everyXRecurrence = recurringExpense.everyXRecurrence,
                     recurrence = getRecurrenceIntFromUIRecurrence(recurringExpense.recurrence),
                     firstPayment = recurringExpense.firstPayment,
+                    color = recurringExpense.color.toInt(),
                 ),
             )
         }
@@ -113,6 +117,7 @@ class RecurringExpenseViewModel(
                     everyXRecurrence = it.everyXRecurrence!!,
                     recurrence = getRecurrenceFromDatabaseInt(it.recurrence!!),
                     firstPayment = it.firstPayment!!,
+                    color = ExpenseColor.fromInt(it.color),
                 ),
             )
         }

--- a/app/src/main/java/de/dbauer/expensetracker/viewmodel/UpcomingPaymentsViewModel.kt
+++ b/app/src/main/java/de/dbauer/expensetracker/viewmodel/UpcomingPaymentsViewModel.kt
@@ -10,6 +10,7 @@ import de.dbauer.expensetracker.data.Recurrence
 import de.dbauer.expensetracker.data.RecurringExpenseData
 import de.dbauer.expensetracker.data.UpcomingPaymentData
 import de.dbauer.expensetracker.isSameDay
+import de.dbauer.expensetracker.ui.customizations.ExpenseColor
 import de.dbauer.expensetracker.viewmodel.database.ExpenseRepository
 import de.dbauer.expensetracker.viewmodel.database.RecurrenceDatabase
 import de.dbauer.expensetracker.viewmodel.database.RecurringExpense
@@ -61,6 +62,7 @@ class UpcomingPaymentsViewModel(
                         everyXRecurrence = it.everyXRecurrence!!,
                         recurrence = getRecurrenceFromDatabaseInt(it.recurrence!!),
                         firstPayment = it.firstPayment!!,
+                        color = ExpenseColor.fromInt(it.color),
                     )
                 onItemClicked(recurringExpenseData)
             }
@@ -83,6 +85,7 @@ class UpcomingPaymentsViewModel(
                         price = it.price!!,
                         nextPaymentRemainingDays = nextPaymentRemainingDays,
                         nextPaymentDate = nextPaymentDate,
+                        color = ExpenseColor.fromInt(it.color),
                     ),
                 )
             }

--- a/app/src/main/java/de/dbauer/expensetracker/viewmodel/database/RecurringExpense.kt
+++ b/app/src/main/java/de/dbauer/expensetracker/viewmodel/database/RecurringExpense.kt
@@ -13,6 +13,7 @@ data class RecurringExpense(
     @ColumnInfo(name = "everyXRecurrence") val everyXRecurrence: Int?,
     @ColumnInfo(name = "recurrence") val recurrence: Int?,
     @ColumnInfo(name = "firstPayment") val firstPayment: Long?,
+    @ColumnInfo(name = "color") val color: Int?,
 ) {
     fun getMonthlyPrice(): Float {
         return when (recurrence) {

--- a/app/src/main/java/de/dbauer/expensetracker/viewmodel/database/RecurringExpenseDatabase.kt
+++ b/app/src/main/java/de/dbauer/expensetracker/viewmodel/database/RecurringExpenseDatabase.kt
@@ -7,7 +7,7 @@ import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
-@Database(entities = [RecurringExpense::class], version = 3)
+@Database(entities = [RecurringExpense::class], version = 4)
 abstract class RecurringExpenseDatabase : RoomDatabase() {
     abstract fun recurringExpenseDao(): RecurringExpenseDao
 
@@ -25,6 +25,7 @@ abstract class RecurringExpenseDatabase : RoomDatabase() {
                     )
                         .addMigrations(migration_1_2)
                         .addMigrations(migration_2_3)
+                        .addMigrations(migration_3_4)
                         .build()
                 instance = tmpInstance
                 tmpInstance
@@ -45,6 +46,13 @@ abstract class RecurringExpenseDatabase : RoomDatabase() {
             object : Migration(2, 3) {
                 override fun migrate(db: SupportSQLiteDatabase) {
                     db.execSQL("ALTER TABLE recurring_expenses ADD COLUMN firstPayment INTEGER DEFAULT 0")
+                }
+            }
+
+        private val migration_3_4 =
+            object : Migration(3, 4) {
+                override fun migrate(db: SupportSQLiteDatabase) {
+                    db.execSQL("ALTER TABLE recurring_expenses ADD COLUMN color INTEGER DEFAULT 0")
                 }
             }
     }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -32,6 +32,7 @@
     <string name="edit_expense_recurrence_year_short">J</string>
     <string name="edit_expense_first_payment">Erste Zahlung (optional)</string>
     <string name="edit_expense_first_payment_placeholder">z.B. Heute</string>
+    <string name="edit_expense_color">Farbe</string>
 
     <!-- Upcoming Payments Tab -->
     <string name="upcoming_title">Ausstehende Zahlungen</string>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="expense_predefined_red">#80ff6666</color>
+    <color name="expense_predefined_orange">#80ffb366</color>
+    <color name="expense_predefined_yellow">#80ffff66</color>
+    <color name="expense_predefined_green">#8066ff66</color>
+    <color name="expense_predefined_mint">#8066ffb3</color>
+    <color name="expense_predefined_turquoise">#8066ffff</color>
+    <color name="expense_predefined_cyan">#8066b2ff</color>
+    <color name="expense_predefined_blue">#807f66ff</color>
+    <color name="expense_predefined_purple">#80cc66ff</color>
+    <color name="expense_predefined_pink">#80ff66ff</color>
+    <color name="expense_predefined_maroon">#80ff66b3</color>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="expense_predefined_red">#80990000</color>
+    <color name="expense_predefined_orange">#80994d00</color>
+    <color name="expense_predefined_yellow">#80999900</color>
+    <color name="expense_predefined_green">#80009900</color>
+    <color name="expense_predefined_mint">#8000994d</color>
+    <color name="expense_predefined_turquoise">#80009999</color>
+    <color name="expense_predefined_cyan">#80004c99</color>
+    <color name="expense_predefined_blue">#80000099</color>
+    <color name="expense_predefined_purple">#804c0099</color>
+    <color name="expense_predefined_pink">#80990099</color>
+    <color name="expense_predefined_maroon">#8099004d</color>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,6 +34,7 @@
     <string name="edit_expense_recurrence_year_short">Y</string>
     <string name="edit_expense_first_payment">First Payment (optional)</string>
     <string name="edit_expense_first_payment_placeholder">e.g. today</string>
+    <string name="edit_expense_color">Color</string>
 
     <!-- Upcoming Payments Tab -->
     <string name="upcoming_title">Upcoming Payments</string>


### PR DESCRIPTION
Defining a color for an expense will color the background of the expense in all lists. This allows a visual grouping of the expenses.

fixes: #85