### PR TITLE
Ignore missing translations warning

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -73,6 +73,9 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+    lint {
+        disable += "MissingTranslation"
+    }
 }
 
 configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {


### PR DESCRIPTION
This allows non complete translations. For strings added by the weblate platform I cannot maintain a 100% translation rate for all languages all the time.