### PR TITLE
Fix bug where BottomSheet was overlapping with navigation bar

### DIFF
--- a/app/src/main/java/de/dbauer/expensetracker/ui/editexpense/EditRecurringExpenseSheet.kt
+++ b/app/src/main/java/de/dbauer/expensetracker/ui/editexpense/EditRecurringExpenseSheet.kt
@@ -2,12 +2,10 @@ package de.dbauer.expensetracker.ui.editexpense
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -60,7 +58,6 @@ fun EditRecurringExpense(
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
         sheetState = sheetState,
-        windowInsets = WindowInsets.statusBars,
         modifier = modifier,
     ) {
         EditRecurringExpenseInternal(


### PR DESCRIPTION
Adjust window insets to use defaults again.
Incorrect colored navigation bar should be fixed with the next Material 3 Compose update.

fixes: #133