### PR TITLE
Fix next payment days calculation

### DIFF
--- a/app/src/main/java/de/dbauer/expensetracker/viewmodel/UpcomingPaymentsViewModel.kt
+++ b/app/src/main/java/de/dbauer/expensetracker/viewmodel/UpcomingPaymentsViewModel.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.launch
 import java.text.DateFormat
 import java.util.Calendar
 import java.util.Date
+import java.util.TimeZone
 import java.util.concurrent.TimeUnit
 
 class UpcomingPaymentsViewModel(
@@ -118,7 +119,7 @@ class UpcomingPaymentsViewModel(
 
     private fun getNextPaymentDays(nextPaymentInMilliseconds: Long): Int {
         val today =
-            Calendar.getInstance().apply {
+            Calendar.getInstance(TimeZone.getTimeZone("UTC")).apply {
                 set(Calendar.HOUR_OF_DAY, 0)
                 set(Calendar.MINUTE, 0)
                 set(Calendar.SECOND, 0)


### PR DESCRIPTION
Use UTC time for both saving the payment day as well as for calculating the days upon that date.

fixes: #130