### PR TITLE
Rename app to "Expenses"

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name" translatable="false">Recurring Expenses</string>
+    <string name="app_name" translatable="false">Expenses</string>
 
     <!-- Bottom Navigation -->
     <string name="bottom_nav_home">Home</string>


### PR DESCRIPTION
This makes the app name short enough to show its full name in the launcher.

fixes: #119