### PR TITLE
Make recurrence input field wider

### DIFF
--- a/app/src/main/java/de/dbauer/expensetracker/ui/editexpense/ExpenseTextField.kt
+++ b/app/src/main/java/de/dbauer/expensetracker/ui/editexpense/ExpenseTextField.kt
@@ -32,6 +32,30 @@ fun ExpenseTextField(
     maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
     isError: Boolean = false,
 ) {
+    val supportingText: (@Composable () -> Unit)? =
+        if (isError) {
+            {
+                Text(
+                    text = stringResource(R.string.edit_expense_invalid_input),
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+        } else {
+            null
+        }
+    val trailingIcon: (@Composable () -> Unit)? =
+        if (isError) {
+            {
+                Icon(
+                    imageVector = Icons.Rounded.Error,
+                    contentDescription = "",
+                    tint = MaterialTheme.colorScheme.error,
+                )
+            }
+        } else {
+            null
+        }
+
     TextField(
         value = value,
         onValueChange = onValueChange,
@@ -41,23 +65,8 @@ fun ExpenseTextField(
         singleLine = singleLine,
         isError = isError,
         maxLines = maxLines,
-        supportingText = {
-            if (isError) {
-                Text(
-                    text = stringResource(R.string.edit_expense_invalid_input),
-                    color = MaterialTheme.colorScheme.error,
-                )
-            }
-        },
-        trailingIcon = {
-            if (isError) {
-                Icon(
-                    imageVector = Icons.Rounded.Error,
-                    contentDescription = "",
-                    tint = MaterialTheme.colorScheme.error,
-                )
-            }
-        },
+        supportingText = supportingText,
+        trailingIcon = trailingIcon,
         modifier = modifier,
     )
 }

--- a/app/src/main/java/de/dbauer/expensetracker/ui/editexpense/RecurrenceOption.kt
+++ b/app/src/main/java/de/dbauer/expensetracker/ui/editexpense/RecurrenceOption.kt
@@ -72,7 +72,7 @@ fun RecurrenceOption(
                 onExpandedChange = { recurrenceExpanded = !recurrenceExpanded },
                 modifier =
                     Modifier
-                        .weight(3f)
+                        .weight(2f)
                         .padding(vertical = 8.dp),
             ) {
                 TextField(


### PR DESCRIPTION
Fix an issue where there was an invisible placeholder for a tailingIcon in the input field. That didn't allow the usage of the full width of the input field.
This should also make sure that the whole number entered is visible.

fixes: #125