### PR TITLE
Move back to a single Scaffold per screen

### DIFF
--- a/app/src/commonMain/kotlin/di/Module.kt
+++ b/app/src/commonMain/kotlin/di/Module.kt
@@ -23,7 +23,7 @@ val sharedModule =
         }.bind<RecurringExpenseDao>()
         viewModelOf(::RecurringExpenseViewModel)
         viewModelOf(::UpcomingPaymentsViewModel)
-        viewModel { (expenseId: Int) ->
+        viewModel { (expenseId: Int?) ->
             EditRecurringExpenseViewModel(expenseId, get())
         }
     }

--- a/app/src/commonMain/kotlin/ui/BottomNavBar.kt
+++ b/app/src/commonMain/kotlin/ui/BottomNavBar.kt
@@ -1,0 +1,74 @@
+package ui
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Home
+import androidx.compose.material.icons.rounded.Payment
+import androidx.compose.material.icons.rounded.Settings
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavController
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.compose.currentBackStackEntryAsState
+import data.BottomNavigation
+import data.HomePane
+import data.SettingsPane
+import data.UpcomingPane
+import org.jetbrains.compose.resources.stringResource
+import recurringexpensetracker.app.generated.resources.Res
+import recurringexpensetracker.app.generated.resources.bottom_nav_home
+import recurringexpensetracker.app.generated.resources.bottom_nav_settings
+import recurringexpensetracker.app.generated.resources.bottom_nav_upcoming
+
+@Composable
+fun BottomNavBar(
+    navController: NavController,
+    modifier: Modifier = Modifier,
+) {
+    val backStackEntry = navController.currentBackStackEntryAsState()
+    val bottomNavigationItems =
+        listOf(
+            BottomNavigation(HomePane.ROUTE, Res.string.bottom_nav_home, Icons.Rounded.Home),
+            BottomNavigation(UpcomingPane.ROUTE, Res.string.bottom_nav_upcoming, Icons.Rounded.Payment),
+            BottomNavigation(SettingsPane.ROUTE, Res.string.bottom_nav_settings, Icons.Rounded.Settings),
+        )
+
+    NavigationBar(modifier = modifier) {
+        bottomNavigationItems.forEach { item ->
+            val selected = item.route == backStackEntry.value?.destination?.route
+
+            NavigationBarItem(
+                selected = selected,
+                onClick = {
+                    navController.navigate(item.route) {
+                        // Pop up to the start destination of the graph to
+                        // avoid building up a large stack of destinations
+                        // on the back stack as users select items
+                        navController.graph.findStartDestination().route?.let { route ->
+                            popUpTo(route) {
+                                saveState = true
+                            }
+                        }
+                        // Avoid multiple copies of the same destination when
+                        // reselecting the same item
+                        launchSingleTop = true
+                        // Restore state when reselecting a previously selected item
+                        restoreState = true
+                    }
+                },
+                icon = {
+                    Icon(
+                        imageVector = item.icon,
+                        contentDescription = null,
+                    )
+                },
+                label = {
+                    Text(text = stringResource(item.name))
+                },
+            )
+        }
+    }
+}

--- a/app/src/commonMain/kotlin/ui/MainContent.kt
+++ b/app/src/commonMain/kotlin/ui/MainContent.kt
@@ -2,37 +2,20 @@ package ui
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.Home
-import androidx.compose.material.icons.rounded.Payment
-import androidx.compose.material.icons.rounded.Settings
-import androidx.compose.material3.Icon
-import androidx.compose.material3.NavigationBar
-import androidx.compose.material3.NavigationBarItem
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
-import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
-import data.BottomNavigation
 import data.EditExpensePane
 import data.EditExpensePane.Companion.getArgExpenseId
 import data.HomePane
 import data.SettingsPane
 import data.UpcomingPane
-import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.KoinContext
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.annotation.KoinExperimentalAPI
-import recurringexpensetracker.app.generated.resources.Res
-import recurringexpensetracker.app.generated.resources.bottom_nav_home
-import recurringexpensetracker.app.generated.resources.bottom_nav_settings
-import recurringexpensetracker.app.generated.resources.bottom_nav_upcoming
 import ui.editexpense.EditRecurringExpenseScreen
 import ui.upcomingexpenses.UpcomingPaymentsScreen
 import viewmodel.RecurringExpenseViewModel
@@ -54,127 +37,64 @@ fun MainContent(
     upcomingPaymentsViewModel: UpcomingPaymentsViewModel = koinViewModel<UpcomingPaymentsViewModel>(),
 ) {
     val navController = rememberNavController()
-    val backStackEntry = navController.currentBackStackEntryAsState()
-
-    val bottomNavigationItems =
-        listOf(
-            BottomNavigation(HomePane.ROUTE, Res.string.bottom_nav_home, Icons.Rounded.Home),
-            BottomNavigation(UpcomingPane.ROUTE, Res.string.bottom_nav_upcoming, Icons.Rounded.Payment),
-            BottomNavigation(SettingsPane.ROUTE, Res.string.bottom_nav_settings, Icons.Rounded.Settings),
-        )
 
     KoinContext {
-        Scaffold(
-            modifier = modifier,
-            bottomBar = {
-                if (backStackEntry.value?.destination?.route in
-                    listOf(HomePane.ROUTE, UpcomingPane.ROUTE, SettingsPane.ROUTE)
-                ) {
-                    NavigationBar {
-                        bottomNavigationItems.forEach { item ->
-                            val selected = item.route == backStackEntry.value?.destination?.route
-
-                            NavigationBarItem(
-                                selected = selected,
-                                onClick = {
-                                    navController.navigate(item.route) {
-                                        // Pop up to the start destination of the graph to
-                                        // avoid building up a large stack of destinations
-                                        // on the back stack as users select items
-                                        navController.graph.findStartDestination().route?.let { route ->
-                                            popUpTo(route) {
-                                                saveState = true
-                                            }
-                                        }
-                                        // Avoid multiple copies of the same destination when
-                                        // reselecting the same item
-                                        launchSingleTop = true
-                                        // Restore state when reselecting a previously selected item
-                                        restoreState = true
-                                    }
-                                },
-                                icon = {
-                                    Icon(
-                                        imageVector = item.icon,
-                                        contentDescription = null,
-                                    )
-                                },
-                                label = {
-                                    Text(text = stringResource(item.name))
-                                },
-                            )
-                        }
-                    }
-                }
-            },
-            content = { _ ->
-                NavHost(
+        NavHost(
+            navController = navController,
+            startDestination = HomePane.ROUTE,
+            modifier = modifier.fillMaxSize(),
+        ) {
+            composable(HomePane.ROUTE) {
+                RecurringExpenseOverview(
+                    weeklyExpense = recurringExpenseViewModel.weeklyExpense,
+                    monthlyExpense = recurringExpenseViewModel.monthlyExpense,
+                    yearlyExpense = recurringExpenseViewModel.yearlyExpense,
+                    recurringExpenseData = recurringExpenseViewModel.recurringExpenseData,
+                    isGridMode = isGridMode,
+                    onToggleGridMode = toggleGridMode,
                     navController = navController,
-                    startDestination = HomePane.ROUTE,
-                    modifier = Modifier.fillMaxSize(),
-                ) {
-                    composable(HomePane.ROUTE) {
-                        RecurringExpenseOverview(
-                            weeklyExpense = recurringExpenseViewModel.weeklyExpense,
-                            monthlyExpense = recurringExpenseViewModel.monthlyExpense,
-                            yearlyExpense = recurringExpenseViewModel.yearlyExpense,
-                            recurringExpenseData = recurringExpenseViewModel.recurringExpenseData,
-                            isGridMode = isGridMode,
-                            onToggleGridMode = toggleGridMode,
-                            onCreateNewExpense = {
-                                navController.navigate(EditExpensePane().destination)
-                            },
-                            onEditExpense = {
-                                navController.navigate(EditExpensePane(it).destination)
-                            },
-                            contentPadding =
-                                PaddingValues(
-                                    top = 8.dp,
-                                    start = 16.dp,
-                                    end = 16.dp,
-                                ),
-                        )
-                    }
-                    composable(UpcomingPane.ROUTE) {
-                        UpcomingPaymentsScreen(
-                            upcomingPaymentsViewModel = upcomingPaymentsViewModel,
-                            onClickItem = {
-                                navController.navigate(EditExpensePane(it.id).destination)
-                            },
-                            isGridMode = isGridMode,
-                            onToggleGridMode = toggleGridMode,
-                            onCreateNewExpense = {
-                                navController.navigate(EditExpensePane().destination)
-                            },
-                            contentPadding =
-                                PaddingValues(
-                                    top = 8.dp,
-                                    start = 16.dp,
-                                    end = 16.dp,
-                                ),
-                        )
-                    }
-                    composable(SettingsPane.ROUTE) {
-                        SettingsScreen(
-                            checked = biometricSecurity,
-                            onClickBackup = onClickBackup,
-                            onClickRestore = onClickRestore,
-                            onCheckedChange = onBiometricSecurityChange,
-                            canUseBiometric = canUseBiometric,
-                        )
-                    }
-                    composable(
-                        route = EditExpensePane.ROUTE,
-                        arguments = EditExpensePane.navArguments,
-                    ) { backStackEntry ->
-                        EditRecurringExpenseScreen(
-                            expenseId = backStackEntry.getArgExpenseId(),
-                            onDismiss = navController::navigateUp,
-                        )
-                    }
-                }
-            },
-        )
+                    contentPadding =
+                        PaddingValues(
+                            top = 8.dp,
+                            start = 16.dp,
+                            end = 16.dp,
+                        ),
+                )
+            }
+            composable(UpcomingPane.ROUTE) {
+                UpcomingPaymentsScreen(
+                    upcomingPaymentsViewModel = upcomingPaymentsViewModel,
+                    isGridMode = isGridMode,
+                    onToggleGridMode = toggleGridMode,
+                    navController = navController,
+                    contentPadding =
+                        PaddingValues(
+                            top = 8.dp,
+                            start = 16.dp,
+                            end = 16.dp,
+                        ),
+                )
+            }
+            composable(SettingsPane.ROUTE) {
+                SettingsScreen(
+                    checked = biometricSecurity,
+                    onClickBackup = onClickBackup,
+                    onClickRestore = onClickRestore,
+                    onCheckedChange = onBiometricSecurityChange,
+                    canUseBiometric = canUseBiometric,
+                    navController = navController,
+                )
+            }
+            composable(
+                route = EditExpensePane.ROUTE,
+                arguments = EditExpensePane.navArguments,
+            ) { backStackEntry ->
+                EditRecurringExpenseScreen(
+                    expenseId = backStackEntry.getArgExpenseId(),
+                    onDismiss = navController::navigateUp,
+                )
+            }
+        }
     }
 }
 

--- a/app/src/commonMain/kotlin/ui/RecurringExpenseOverview.kt
+++ b/app/src/commonMain/kotlin/ui/RecurringExpenseOverview.kt
@@ -38,6 +38,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import data.EditExpensePane
 import data.Recurrence
 import data.RecurringExpenseData
 import kotlinx.datetime.Clock
@@ -64,8 +67,7 @@ fun RecurringExpenseOverview(
     recurringExpenseData: List<RecurringExpenseData>,
     isGridMode: Boolean,
     onToggleGridMode: () -> Unit,
-    onCreateNewExpense: () -> Unit,
-    onEditExpense: (expenseId: Int) -> Unit,
+    navController: NavController,
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(0.dp),
 ) {
@@ -91,9 +93,14 @@ fun RecurringExpenseOverview(
                 },
             )
         },
+        bottomBar = {
+            BottomNavBar(navController = navController)
+        },
         floatingActionButton = {
             FloatingActionButton(
-                onClick = onCreateNewExpense,
+                onClick = {
+                    navController.navigate(EditExpensePane().destination)
+                },
             ) {
                 Icon(
                     imageVector = Icons.Rounded.Add,
@@ -151,14 +158,14 @@ fun RecurringExpenseOverview(
                             GridRecurringExpense(
                                 recurringExpenseData = recurringExpenseData,
                                 onClickItem = {
-                                    onEditExpense(recurringExpenseData.id)
+                                    navController.navigate(EditExpensePane(recurringExpenseData.id).destination)
                                 },
                             )
                         } else {
                             RecurringExpense(
                                 recurringExpenseData = recurringExpenseData,
                                 onClickItem = {
-                                    onEditExpense(recurringExpenseData.id)
+                                    navController.navigate(EditExpensePane(recurringExpenseData.id).destination)
                                 },
                             )
                         }
@@ -415,8 +422,7 @@ private fun RecurringExpenseOverviewPreview(
                     ),
                 isGridMode = isGridMode,
                 onToggleGridMode = { },
-                onCreateNewExpense = { },
-                onEditExpense = {},
+                navController = rememberNavController(),
             )
         }
     }

--- a/app/src/commonMain/kotlin/ui/SettingsScreen.kt
+++ b/app/src/commonMain/kotlin/ui/SettingsScreen.kt
@@ -28,6 +28,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -50,6 +52,7 @@ fun SettingsScreen(
     onClickBackup: () -> Unit,
     onClickRestore: () -> Unit,
     onCheckedChange: (Boolean) -> Unit,
+    navController: NavController,
     modifier: Modifier = Modifier,
 ) {
     Scaffold(
@@ -58,6 +61,9 @@ fun SettingsScreen(
             TopAppBar(
                 title = { Text(text = stringResource(Res.string.settings_title)) },
             )
+        },
+        bottomBar = {
+            BottomNavBar(navController = navController)
         },
         content = { paddingValues ->
             Column(
@@ -178,6 +184,7 @@ private fun SettingsScreenPreview(
                 onClickBackup = {},
                 onClickRestore = {},
                 onCheckedChange = { checked = it },
+                navController = rememberNavController(),
             )
         }
     }

--- a/app/src/commonMain/kotlin/ui/upcomingexpenses/UpcomingPaymentsScreen.kt
+++ b/app/src/commonMain/kotlin/ui/upcomingexpenses/UpcomingPaymentsScreen.kt
@@ -40,7 +40,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import data.RecurringExpenseData
+import androidx.navigation.NavController
+import data.EditExpensePane
 import data.UpcomingPaymentData
 import kotlinx.datetime.Clock
 import org.jetbrains.compose.resources.stringResource
@@ -54,6 +55,7 @@ import recurringexpensetracker.app.generated.resources.upcoming_time_remaining_t
 import recurringexpensetracker.app.generated.resources.upcoming_title
 import toCurrencyString
 import toLocaleString
+import ui.BottomNavBar
 import ui.ToggleGridModeButton
 import ui.customizations.ExpenseColor
 import ui.theme.ExpenseTrackerTheme
@@ -63,10 +65,9 @@ import viewmodel.UpcomingPaymentsViewModel
 @Composable
 fun UpcomingPaymentsScreen(
     upcomingPaymentsViewModel: UpcomingPaymentsViewModel,
-    onClickItem: (RecurringExpenseData) -> Unit,
     isGridMode: Boolean,
     onToggleGridMode: () -> Unit,
-    onCreateNewExpense: () -> Unit,
+    navController: NavController,
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(0.dp),
 ) {
@@ -87,9 +88,14 @@ fun UpcomingPaymentsScreen(
                 },
             )
         },
+        bottomBar = {
+            BottomNavBar(navController = navController)
+        },
         floatingActionButton = {
             FloatingActionButton(
-                onClick = onCreateNewExpense,
+                onClick = {
+                    navController.navigate(EditExpensePane().destination)
+                },
             ) {
                 Icon(
                     imageVector = Icons.Rounded.Add,
@@ -102,8 +108,10 @@ fun UpcomingPaymentsScreen(
             if (upcomingPaymentsViewModel.upcomingPaymentsData.isNotEmpty()) {
                 UpcomingPaymentsOverview(
                     upcomingPaymentsData = upcomingPaymentsViewModel.upcomingPaymentsData,
-                    onClickItem = {
-                        upcomingPaymentsViewModel.onExpenseWithIdClicked(it, onClickItem)
+                    onClickItem = { expenseId ->
+                        upcomingPaymentsViewModel.onExpenseWithIdClicked(expenseId) {
+                            navController.navigate(EditExpensePane(expenseId).destination)
+                        }
                     },
                     isGridMode = isGridMode,
                     modifier = Modifier.padding(paddingValues),


### PR DESCRIPTION
Instead of two separate Scaffolds move back to a single Scaffold per screen as having multiple Scaffold messed things up. E.g. the FAB was behind the NavBar and some paddings weren't correct. Still having a Scaffold per screen so actions, bottomBar, FAB and others
 can be configured per screen.