### PR TITLE
Persist grid mode for iOS and desktop platforms

### DIFF
--- a/app/src/androidMain/kotlin/de/dbauer/expensetracker/ExpenseTrackerApplication.kt
+++ b/app/src/androidMain/kotlin/de/dbauer/expensetracker/ExpenseTrackerApplication.kt
@@ -1,18 +1,12 @@
 package de.dbauer.expensetracker
 
 import android.app.Application
-import android.content.Context
-import androidx.datastore.preferences.preferencesDataStore
 import di.platformModule
 import di.sharedModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.context.startKoin
-import viewmodel.database.UserPreferencesRepository
 
 class ExpenseTrackerApplication : Application() {
-    private val Context.dataStore by preferencesDataStore(name = USER_PREFERENCES_DATA_STORE)
-    val userPreferencesRepository by lazy { UserPreferencesRepository(dataStore = dataStore) }
-
     override fun onCreate() {
         super.onCreate()
 
@@ -23,9 +17,5 @@ class ExpenseTrackerApplication : Application() {
                 platformModule,
             )
         }
-    }
-
-    private companion object {
-        private const val USER_PREFERENCES_DATA_STORE = "USER_PREFERENCES_DATA_STORE"
     }
 }

--- a/app/src/androidMain/kotlin/de/dbauer/expensetracker/MainActivity.kt
+++ b/app/src/androidMain/kotlin/de/dbauer/expensetracker/MainActivity.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import model.DatabaseBackupRestore
 import org.jetbrains.compose.resources.stringResource
+import org.koin.android.ext.android.get
 import recurringexpensetracker.app.generated.resources.Res
 import recurringexpensetracker.app.generated.resources.biometric_prompt_manager_title
 import recurringexpensetracker.app.generated.resources.biometric_prompt_manager_unlock
@@ -49,9 +50,7 @@ import java.io.File
 
 class MainActivity : AppCompatActivity() {
     private val databasePath by lazy { getDatabasePath(Constants.DATABASE_NAME).path }
-    private val userPreferencesRepository: UserPreferencesRepository by lazy {
-        (application as ExpenseTrackerApplication).userPreferencesRepository
-    }
+    private val userPreferencesRepository = get<UserPreferencesRepository>()
     private val mainActivityViewModel: MainActivityViewModel by viewModels()
 
     private val biometricPromptManager: BiometricPromptManager by lazy { BiometricPromptManager(this) }

--- a/app/src/androidMain/kotlin/di/Module.android.kt
+++ b/app/src/androidMain/kotlin/di/Module.android.kt
@@ -1,13 +1,27 @@
 package di
 
+import Constants
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStoreFile
 import androidx.room.RoomDatabase
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
 import viewmodel.database.RecurringExpenseDatabase
+import viewmodel.database.UserPreferencesRepository
 import viewmodel.database.getDatabaseBuilder
 
 actual val platformModule =
     module {
         singleOf(::getDatabaseBuilder).bind<RoomDatabase.Builder<RecurringExpenseDatabase>>()
+        single<DataStore<Preferences>> {
+            val context = get<Context>()
+            PreferenceDataStoreFactory.create {
+                context.preferencesDataStoreFile(name = Constants.USER_PREFERENCES_DATA_STORE)
+            }
+        }
+        singleOf(::UserPreferencesRepository)
     }

--- a/app/src/commonMain/kotlin/Constants.kt
+++ b/app/src/commonMain/kotlin/Constants.kt
@@ -2,4 +2,5 @@ object Constants {
     const val DATABASE_NAME = "recurring-expenses"
     const val DEFAULT_BACKUP_NAME = "$DATABASE_NAME.rexp"
     const val BACKUP_MIME_TYPE = "application/octet-stream"
+    const val USER_PREFERENCES_DATA_STORE = "USER_PREFERENCES_DATA_STORE"
 }

--- a/app/src/desktopMain/kotlin/Main.kt
+++ b/app/src/desktopMain/kotlin/Main.kt
@@ -1,13 +1,16 @@
+
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import di.platformModule
 import di.sharedModule
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.koin.compose.koinInject
 import org.koin.core.context.startKoin
 import ui.MainContent
+import viewmodel.database.UserPreferencesRepository
 
 fun main() =
     application {
@@ -15,7 +18,8 @@ fun main() =
             modules(sharedModule, platformModule)
         }
 
-        var isGridMode by remember { mutableStateOf(false) }
+        val userPreferencesRepository = koinInject<UserPreferencesRepository>()
+        val isGridMode by userPreferencesRepository.gridMode.collectAsState()
 
         Window(
             onCloseRequest = ::exitApplication,
@@ -26,7 +30,9 @@ fun main() =
                 biometricSecurity = false,
                 canUseBiometric = false,
                 toggleGridMode = {
-                    isGridMode = !isGridMode
+                    CoroutineScope(Dispatchers.Main).launch {
+                        userPreferencesRepository.gridMode.save(!isGridMode)
+                    }
                 },
                 onBiometricSecurityChange = {},
                 onClickBackup = {},

--- a/app/src/desktopMain/kotlin/di/Module.desktop.kt
+++ b/app/src/desktopMain/kotlin/di/Module.desktop.kt
@@ -1,13 +1,29 @@
 package di
 
+import Constants
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
 import androidx.room.RoomDatabase
+import okio.Path.Companion.toOkioPath
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
 import viewmodel.database.RecurringExpenseDatabase
+import viewmodel.database.UserPreferencesRepository
 import viewmodel.database.getDatabaseBuilder
+import java.io.File
 
 actual val platformModule =
     module {
         singleOf(::getDatabaseBuilder).bind<RoomDatabase.Builder<RecurringExpenseDatabase>>()
+        single<DataStore<Preferences>> {
+            PreferenceDataStoreFactory.createWithPath {
+                File(
+                    System.getProperty("java.io.tmpdir"),
+                    "${Constants.USER_PREFERENCES_DATA_STORE}.preferences_pb",
+                ).toOkioPath()
+            }
+        }
+        singleOf(::UserPreferencesRepository)
     }

--- a/app/src/iosMain/kotlin/MainViewController.kt
+++ b/app/src/iosMain/kotlin/MainViewController.kt
@@ -2,16 +2,18 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.window.ComposeUIViewController
 import di.platformModule
 import di.sharedModule
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.koin.compose.koinInject
 import org.koin.core.context.startKoin
 import ui.MainContent
 import ui.theme.ExpenseTrackerTheme
+import viewmodel.database.UserPreferencesRepository
 
 fun MainViewController() =
     ComposeUIViewController {
@@ -19,7 +21,8 @@ fun MainViewController() =
             modules(sharedModule, platformModule)
         }
 
-        var isGridMode by remember { mutableStateOf(false) }
+        val userPreferencesRepository = koinInject<UserPreferencesRepository>()
+        val isGridMode by userPreferencesRepository.gridMode.collectAsState()
 
         ExpenseTrackerTheme {
             Surface(
@@ -31,7 +34,9 @@ fun MainViewController() =
                     biometricSecurity = false,
                     canUseBiometric = false,
                     toggleGridMode = {
-                        isGridMode = !isGridMode
+                        CoroutineScope(Dispatchers.Main).launch {
+                            userPreferencesRepository.gridMode.save(!isGridMode)
+                        }
                     },
                     onBiometricSecurityChange = {},
                     onClickBackup = {},

--- a/app/src/iosMain/kotlin/di/Module.ios.kt
+++ b/app/src/iosMain/kotlin/di/Module.ios.kt
@@ -1,13 +1,40 @@
 package di
 
+import Constants
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
 import androidx.room.RoomDatabase
+import kotlinx.cinterop.ExperimentalForeignApi
+import okio.Path.Companion.toPath
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
+import platform.Foundation.NSDocumentDirectory
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSURL
+import platform.Foundation.NSUserDomainMask
 import viewmodel.database.RecurringExpenseDatabase
+import viewmodel.database.UserPreferencesRepository
 import viewmodel.database.getDatabaseBuilder
 
+@OptIn(ExperimentalForeignApi::class)
 actual val platformModule =
     module {
         singleOf(::getDatabaseBuilder).bind<RoomDatabase.Builder<RecurringExpenseDatabase>>()
+        single<DataStore<Preferences>> {
+            PreferenceDataStoreFactory.createWithPath {
+                val documentDirectory: NSURL? =
+                    NSFileManager.defaultManager.URLForDirectory(
+                        directory = NSDocumentDirectory,
+                        inDomain = NSUserDomainMask,
+                        appropriateForURL = null,
+                        create = false,
+                        error = null,
+                    )
+                "${requireNotNull(documentDirectory).path}/${Constants.USER_PREFERENCES_DATA_STORE}.preferences_pb"
+                    .toPath()
+            }
+        }
+        singleOf(::UserPreferencesRepository)
     }


### PR DESCRIPTION
Allow usage of DataStore in common code.
This allows saving the gridMode in the preferences for iOS and desktop and also allows saving more to the DataStore in the future.