### PR TITLE
Fix bug wrong date calculation

### DIFF
--- a/app/src/commonMain/kotlin/Extensions.kt
+++ b/app/src/commonMain/kotlin/Extensions.kt
@@ -1,6 +1,5 @@
 import androidx.compose.ui.Modifier
 import kotlinx.datetime.Instant
-import kotlinx.datetime.LocalDate
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.getString
 
@@ -9,28 +8,6 @@ expect fun Float.toCurrencyString(currencyCode: String): String
 expect fun Float.toLocalString(): String
 
 expect fun String.toFloatLocaleAware(): Float?
-
-fun LocalDate.isSameDay(other: LocalDate): Boolean {
-    return this.year == other.year &&
-        this.month == other.month &&
-        this.dayOfMonth == other.dayOfMonth
-}
-
-fun LocalDate.isInDaysAfter(other: LocalDate): Boolean {
-    if (this.year > other.year) {
-        return true
-    } else if (this.year == other.year &&
-        this.month > other.month
-    ) {
-        return true
-    } else if (this.year == other.year &&
-        this.month == other.month &&
-        this.dayOfMonth > other.dayOfMonth
-    ) {
-        return true
-    }
-    return false
-}
 
 fun Modifier.conditional(
     condition: Boolean,

--- a/app/src/commonMain/kotlin/model/DateTimeCalculator.kt
+++ b/app/src/commonMain/kotlin/model/DateTimeCalculator.kt
@@ -1,0 +1,72 @@
+package model
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.daysUntil
+import kotlinx.datetime.plus
+import kotlinx.datetime.toLocalDateTime
+
+object DateTimeCalculator {
+    fun getDaysFromNowUntil(until: LocalDate): Int {
+        return getDaysFromUntil(Clock.System.now(), until)
+    }
+
+    fun getDaysFromUntil(
+        from: Instant,
+        until: LocalDate,
+        fromTimeZone: TimeZone = TimeZone.currentSystemDefault(),
+    ): Int {
+        val fromStartOfDay = from.toLocalDateTime(fromTimeZone).date.atStartOfDayIn(TimeZone.UTC)
+        return fromStartOfDay.daysUntil(until.atStartOfDayIn(TimeZone.UTC), TimeZone.UTC)
+    }
+
+    fun getDayOfNextOccurrenceFromNow(
+        from: Instant,
+        everyXRecurrence: Int,
+        recurrence: DateTimeUnit.DateBased,
+    ): LocalDate {
+        return getDayOfNextOccurrence(Clock.System.now(), from, everyXRecurrence, recurrence)
+    }
+
+    fun getDayOfNextOccurrence(
+        atPointInTime: Instant,
+        first: Instant,
+        everyXRecurrence: Int,
+        recurrence: DateTimeUnit.DateBased,
+        atPointInTimeZone: TimeZone = TimeZone.currentSystemDefault(),
+    ): LocalDate {
+        val pointInTime = atPointInTime.toLocalDateTime(atPointInTimeZone).date
+        var nextOccurrence = first.toLocalDateTime(TimeZone.UTC).date
+
+        while (pointInTime.isInDaysAfter(nextOccurrence) && !pointInTime.isSameDay(nextOccurrence)) {
+            nextOccurrence = nextOccurrence.plus(everyXRecurrence, recurrence)
+        }
+        return nextOccurrence
+    }
+
+    private fun LocalDate.isSameDay(other: LocalDate): Boolean {
+        return this.year == other.year &&
+            this.month == other.month &&
+            this.dayOfMonth == other.dayOfMonth
+    }
+
+    private fun LocalDate.isInDaysAfter(other: LocalDate): Boolean {
+        if (this.year > other.year) {
+            return true
+        } else if (this.year == other.year &&
+            this.month > other.month
+        ) {
+            return true
+        } else if (this.year == other.year &&
+            this.month == other.month &&
+            this.dayOfMonth > other.dayOfMonth
+        ) {
+            return true
+        }
+        return false
+    }
+}

--- a/app/src/commonMain/kotlin/ui/editexpense/FirstPaymentOption.kt
+++ b/app/src/commonMain/kotlin/ui/editexpense/FirstPaymentOption.kt
@@ -123,7 +123,7 @@ private fun Instant?.orNowIfInvalid(): Long {
     return this?.toEpochMilliseconds()
         ?: Clock.System
             .now()
-            .toLocalDateTime(TimeZone.UTC)
+            .toLocalDateTime(TimeZone.currentSystemDefault())
             .toInstant(TimeZone.UTC)
             .toEpochMilliseconds()
 }

--- a/app/src/commonMain/kotlin/viewmodel/UpcomingPaymentsViewModel.kt
+++ b/app/src/commonMain/kotlin/viewmodel/UpcomingPaymentsViewModel.kt
@@ -6,18 +6,11 @@ import androidx.lifecycle.viewModelScope
 import data.Recurrence
 import data.RecurringExpenseData
 import data.UpcomingPaymentData
-import isInDaysAfter
-import isSameDay
 import kotlinx.coroutines.launch
-import kotlinx.datetime.Clock
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.atStartOfDayIn
-import kotlinx.datetime.daysUntil
-import kotlinx.datetime.plus
-import kotlinx.datetime.toLocalDateTime
+import model.DateTimeCalculator
 import model.database.ExpenseRepository
 import model.database.RecurrenceDatabase
 import model.database.RecurringExpense
@@ -89,29 +82,22 @@ class UpcomingPaymentsViewModel(
         everyXRecurrence: Int,
         recurrence: Int,
     ): LocalDate {
-        val today =
-            Clock.System
-                .now()
-                .toLocalDateTime(TimeZone.UTC)
-                .date
-        var nextPayment = firstPayment.toLocalDateTime(TimeZone.UTC).date
-
-        while (today.isInDaysAfter(nextPayment) && !today.isSameDay(nextPayment)) {
-            val field =
+        return DateTimeCalculator.getDayOfNextOccurrenceFromNow(
+            from = firstPayment,
+            everyXRecurrence = everyXRecurrence,
+            recurrence =
                 when (recurrence) {
                     RecurrenceDatabase.Daily.value -> DateTimeUnit.DAY
                     RecurrenceDatabase.Weekly.value -> DateTimeUnit.WEEK
                     RecurrenceDatabase.Monthly.value -> DateTimeUnit.MONTH
                     RecurrenceDatabase.Yearly.value -> DateTimeUnit.YEAR
                     else -> DateTimeUnit.MONTH
-                }
-            nextPayment = nextPayment.plus(everyXRecurrence, field)
-        }
-        return nextPayment
+                },
+        )
     }
 
     private fun getNextPaymentDays(nextPaymentDay: LocalDate): Int {
-        return Clock.System.now().daysUntil(nextPaymentDay.atStartOfDayIn(TimeZone.UTC), TimeZone.UTC)
+        return DateTimeCalculator.getDaysFromNowUntil(nextPaymentDay)
     }
 
     private fun getRecurrenceFromDatabaseInt(recurrenceInt: Int): Recurrence {

--- a/app/src/commonTest/kotlin/model/DateTimeCalculatorTest.kt
+++ b/app/src/commonTest/kotlin/model/DateTimeCalculatorTest.kt
@@ -1,0 +1,255 @@
+package model
+
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DateTimeCalculatorTest {
+    @Test
+    fun checkDayCalculationWorksFromAnyTimeOfDay() {
+        val expected = 1
+
+        for (hour in 0..23) {
+            val actual =
+                DateTimeCalculator.getDaysFromUntil(
+                    from = LocalDateTime(2024, 7, 21, hour, 0, 7, 10).toInstant(TimeZone.currentSystemDefault()),
+                    until = LocalDate(2024, 7, 22),
+                )
+
+            assertEquals(expected, actual, "Failed the data calculation didn't work using hour $hour")
+        }
+    }
+
+    @Test
+    fun checkDayCalculationFromDifferentTimeZones() {
+        val expected = 34
+
+        listOf(
+            TimeZone.of("America/New_York"),
+            TimeZone.of("Pacific/Midway"),
+            TimeZone.of("Asia/Tokyo"),
+        ).forEach { timeZone ->
+            var actual =
+                DateTimeCalculator.getDaysFromUntil(
+                    from = LocalDateTime(2024, 6, 18, 0, 0, 7, 10).toInstant(timeZone),
+                    until = LocalDate(2024, 7, 22),
+                    fromTimeZone = timeZone,
+                )
+            assertEquals(expected, actual)
+
+            actual =
+                DateTimeCalculator.getDaysFromUntil(
+                    from = LocalDateTime(2024, 6, 18, 23, 0, 7, 10).toInstant(timeZone),
+                    until = LocalDate(2024, 7, 22),
+                    fromTimeZone = timeZone,
+                )
+
+            assertEquals(expected, actual, "Failed the data calculation didn't work using time zone: $timeZone")
+        }
+    }
+
+    @Test
+    fun checkDayOfNextOccurrenceFromAnyTimeOfDay() {
+        val expected = LocalDate(2024, 7, 12)
+
+        for (hour in 0..23) {
+            val actual =
+                DateTimeCalculator.getDayOfNextOccurrence(
+                    atPointInTime =
+                        LocalDateTime(2024, 7, 1, hour, 0, 7, 10)
+                            .toInstant(TimeZone.currentSystemDefault()),
+                    first =
+                        LocalDateTime(2024, 5, 12, 0, 0, 0, 0)
+                            .toInstant(TimeZone.UTC),
+                    everyXRecurrence = 1,
+                    recurrence = DateTimeUnit.MONTH,
+                )
+
+            assertEquals(expected, actual, "Failed the data calculation didn't work using hour $hour")
+        }
+    }
+
+    @Test
+    fun checkDayOfNextOccurrenceFromDifferentTimeZones() {
+        val expected = LocalDate(2024, 6, 1)
+
+        listOf(
+            TimeZone.of("America/New_York"),
+            TimeZone.of("Pacific/Midway"),
+            TimeZone.of("Asia/Tokyo"),
+        ).forEach { timeZone ->
+            var actual =
+                DateTimeCalculator.getDayOfNextOccurrence(
+                    atPointInTime =
+                        LocalDateTime(2024, 5, 29, 0, 0, 7, 10)
+                            .toInstant(timeZone),
+                    first =
+                        LocalDateTime(2023, 11, 1, 0, 0, 0, 0)
+                            .toInstant(TimeZone.UTC),
+                    everyXRecurrence = 1,
+                    recurrence = DateTimeUnit.MONTH,
+                    atPointInTimeZone = timeZone,
+                )
+
+            assertEquals(expected, actual, "Failed the data calculation didn't work using time zone: $timeZone")
+
+            actual =
+                DateTimeCalculator.getDayOfNextOccurrence(
+                    atPointInTime =
+                        LocalDateTime(2024, 5, 29, 0, 0, 7, 10)
+                            .toInstant(timeZone),
+                    first =
+                        LocalDateTime(2023, 11, 1, 0, 0, 0, 0)
+                            .toInstant(TimeZone.UTC),
+                    everyXRecurrence = 1,
+                    recurrence = DateTimeUnit.MONTH,
+                    atPointInTimeZone = timeZone,
+                )
+
+            assertEquals(expected, actual, "Failed the data calculation didn't work using time zone: $timeZone")
+        }
+    }
+
+    @Test
+    fun checkDayOfNextOccurrenceWithDailyRecurrence() {
+        var expected = LocalDate(2024, 5, 25)
+        var actual =
+            DateTimeCalculator.getDayOfNextOccurrence(
+                atPointInTime =
+                    LocalDateTime(2024, 5, 25, 1, 0, 7, 10)
+                        .toInstant(TimeZone.currentSystemDefault()),
+                first =
+                    LocalDateTime(2024, 4, 30, 0, 0, 0, 0)
+                        .toInstant(TimeZone.UTC),
+                everyXRecurrence = 1,
+                recurrence = DateTimeUnit.DAY,
+            )
+        assertEquals(expected, actual)
+
+        expected = LocalDate(2024, 5, 25)
+        actual =
+            DateTimeCalculator.getDayOfNextOccurrence(
+                atPointInTime =
+                    LocalDateTime(2024, 5, 24, 1, 0, 7, 10)
+                        .toInstant(TimeZone.currentSystemDefault()),
+                first =
+                    LocalDateTime(2024, 4, 30, 0, 0, 0, 0)
+                        .toInstant(TimeZone.UTC),
+                everyXRecurrence = 5,
+                recurrence = DateTimeUnit.DAY,
+            )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun checkDayOfNextOccurrenceWithWeeklyRecurrence() {
+        var expected = LocalDate(2024, 6, 20)
+        var actual =
+            DateTimeCalculator.getDayOfNextOccurrence(
+                atPointInTime =
+                    LocalDateTime(2024, 6, 14, 1, 0, 7, 10)
+                        .toInstant(TimeZone.currentSystemDefault()),
+                first =
+                    LocalDateTime(2024, 5, 2, 0, 0, 0, 0)
+                        .toInstant(TimeZone.UTC),
+                everyXRecurrence = 1,
+                recurrence = DateTimeUnit.WEEK,
+            )
+        assertEquals(expected, actual)
+
+        expected = LocalDate(2024, 6, 27)
+        actual =
+            DateTimeCalculator.getDayOfNextOccurrence(
+                atPointInTime =
+                    LocalDateTime(2024, 6, 14, 1, 0, 7, 10)
+                        .toInstant(TimeZone.currentSystemDefault()),
+                first =
+                    LocalDateTime(2024, 5, 2, 0, 0, 0, 0)
+                        .toInstant(TimeZone.UTC),
+                everyXRecurrence = 2,
+                recurrence = DateTimeUnit.WEEK,
+            )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun checkDayOfNextOccurrenceWithMonthlyRecurrence() {
+        // Verify monthly edge case e.g. with February when defining a day which isn't available in the next month
+        var expected = LocalDate(2024, 2, 29)
+        var actual =
+            DateTimeCalculator.getDayOfNextOccurrence(
+                atPointInTime =
+                    LocalDateTime(2024, 2, 28, 1, 0, 7, 10)
+                        .toInstant(TimeZone.currentSystemDefault()),
+                first =
+                    LocalDateTime(2024, 1, 30, 0, 0, 0, 0)
+                        .toInstant(TimeZone.UTC),
+                everyXRecurrence = 1,
+                recurrence = DateTimeUnit.MONTH,
+            )
+        assertEquals(expected, actual)
+
+        expected = LocalDate(2024, 6, 15)
+        actual =
+            DateTimeCalculator.getDayOfNextOccurrence(
+                atPointInTime =
+                    LocalDateTime(2024, 6, 15, 1, 0, 7, 10)
+                        .toInstant(TimeZone.currentSystemDefault()),
+                first =
+                    LocalDateTime(2023, 12, 15, 0, 0, 0, 0)
+                        .toInstant(TimeZone.UTC),
+                everyXRecurrence = 3,
+                recurrence = DateTimeUnit.MONTH,
+            )
+        assertEquals(expected, actual)
+
+        expected = LocalDate(2024, 6, 15)
+        actual =
+            DateTimeCalculator.getDayOfNextOccurrence(
+                atPointInTime =
+                    LocalDateTime(2024, 5, 16, 1, 0, 7, 10)
+                        .toInstant(TimeZone.currentSystemDefault()),
+                first =
+                    LocalDateTime(2023, 12, 15, 0, 0, 0, 0)
+                        .toInstant(TimeZone.UTC),
+                everyXRecurrence = 3,
+                recurrence = DateTimeUnit.MONTH,
+            )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun checkDayOfNextOccurrenceWithYearlyRecurrence() {
+        var expected = LocalDate(2024, 6, 1)
+        var actual =
+            DateTimeCalculator.getDayOfNextOccurrence(
+                atPointInTime =
+                    LocalDateTime(2024, 5, 29, 23, 0, 7, 10)
+                        .toInstant(TimeZone.currentSystemDefault()),
+                first =
+                    LocalDateTime(2023, 6, 1, 0, 0, 0, 0)
+                        .toInstant(TimeZone.UTC),
+                everyXRecurrence = 1,
+                recurrence = DateTimeUnit.YEAR,
+            )
+        assertEquals(expected, actual)
+
+        expected = LocalDate(2026, 6, 1)
+        actual =
+            DateTimeCalculator.getDayOfNextOccurrence(
+                atPointInTime =
+                    LocalDateTime(2024, 6, 2, 1, 0, 7, 10)
+                        .toInstant(TimeZone.currentSystemDefault()),
+                first =
+                    LocalDateTime(2022, 6, 1, 0, 0, 0, 0)
+                        .toInstant(TimeZone.UTC),
+                everyXRecurrence = 2,
+                recurrence = DateTimeUnit.YEAR,
+            )
+        assertEquals(expected, actual)
+    }
+}

--- a/app/src/commonTest/kotlin/model/database/RecurringExpenseTest.kt
+++ b/app/src/commonTest/kotlin/model/database/RecurringExpenseTest.kt
@@ -1,7 +1,5 @@
-package viewmodel.database
+package model.database
 
-import model.database.RecurrenceDatabase
-import model.database.RecurringExpense
 import kotlin.test.Test
 import kotlin.test.assertEquals
 


### PR DESCRIPTION
Fix an issue where the date for the next payment wasn't calculated
correctly as it was using the current time of the day instead of the
day in general.

Extract days until calculation and the next payment date calculation
into a separate class and cover it with UnitTests preventing this from
happening again in the future. 🤞

fixes #272