### PR TITLE
Make release tags builds are reproducible again

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,14 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-      - name: Run Python script
-        run: python .github/scripts/update_exchange_rates.py
-        env:
-          CURRENCY_EXCHANGE_API_KEY: ${{ secrets.CURRENCY_EXCHANGE_API_KEY }}
       - name: Use Java 17
         uses: actions/setup-java@v4
         with:
@@ -55,14 +47,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-      - name: Run Python script
-        run: python .github/scripts/update_exchange_rates.py
-        env:
-          CURRENCY_EXCHANGE_API_KEY: ${{ secrets.CURRENCY_EXCHANGE_API_KEY }}
       - name: Use Java 17
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/trigger_new_release.yml
+++ b/.github/workflows/trigger_new_release.yml
@@ -1,0 +1,37 @@
+name: Update exchange rates and trigger new release
+
+permissions:
+  contents: write
+  pull-requests: read
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update-exchange-rates:
+    name: Update currency exchange rates and trigger new release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Run Python script
+        run: python .github/scripts/update_exchange_rates.py
+        env:
+          CURRENCY_EXCHANGE_API_KEY: ${{ secrets.CURRENCY_EXCHANGE_API_KEY }}
+      - name: Read versionName from build.gradle.kts and write to env variable
+        run: |
+          currentVersionName=$(grep 'versionName = ' app/build.gradle.kts | awk -F '"' '{print $2}')
+          echo "VERSION_NAME=$currentVersionName" >> $GITHUB_ENV
+      - name: Commit changes
+        uses: EndBug/add-and-commit@v9
+        with:
+          add : |
+            - app/src/commonMain/composeResources/files/exchange_rates.json
+          message: |
+            Create new release ${{ env.VERSION_NAME }}
+
+            Update exchange rates
+          tag: v${{ env.VERSION_NAME }}


### PR DESCRIPTION
Create separate Github action to update exchange rates

Remove updating expenses in release pipeline to build the tagged commit without any modifications.

fixes: #296