### PR TITLE
Update to actions/download-artifact v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,15 +84,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download APK from build
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: apk
       - name: Download aab from build
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: appbundle
       - name: Download whatsnew from build
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: whatsnew
       - id: get_version


### PR DESCRIPTION
This is needed as v1 and v2 got deprecated and won't work anymore