### PR TITLE
Remove obsolete disableCompilerDaemon flag

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,5 +10,3 @@ android.useAndroidX=true
 #MPP
 kotlin.mpp.androidSourceSetLayoutVersion=2
 kotlin.mpp.enableCInteropCommonization=true
-
-kotlin.native.disableCompilerDaemon = true


### PR DESCRIPTION
This was only needed in the past for older KMP versions and not needed anymore.