### PR TITLE
Ignore actual expect warning

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,6 +19,11 @@ kotlin {
         }
     }
 
+    compilerOptions {
+        // Common compiler options applied to all Kotlin source sets
+        freeCompilerArgs.add("-Xexpect-actual-classes")
+    }
+
     jvm("desktop")
 
     listOf(


### PR DESCRIPTION
Ignore `-Xexpect-actual-classes` which is a warning from the Room database in common code.
Also see: https://youtrack.jetbrains.com/issue/KT-61573