### PR TITLE
Add basic widget support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,6 +49,8 @@ kotlin {
 
             implementation(libs.koin.android)
             implementation(libs.koin.androidx.compose)
+            implementation(libs.androidx.glance.appwidget)
+            implementation(libs.androidx.glance.material3)
         }
         commonMain.dependencies {
             implementation(compose.components.resources)
@@ -148,14 +150,19 @@ android {
     }
 }
 
-compose.desktop {
-    application {
-        mainClass = "MainKt"
+compose {
+    resources {
+        publicResClass = true
+    }
+    desktop {
+        application {
+            mainClass = "MainKt"
 
-        nativeDistributions {
-            targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
-            packageName = "de.dbauer.expensetracker"
-            packageVersion = "1.0.0"
+            nativeDistributions {
+                targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
+                packageName = "de.dbauer.expensetracker"
+                packageVersion = "1.0.0"
+            }
         }
     }
 }

--- a/app/src/androidMain/AndroidManifest.xml
+++ b/app/src/androidMain/AndroidManifest.xml
@@ -23,6 +23,15 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <receiver android:name=".widget.UpcomingPaymentsWidgetReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/my_app_widget_info" />
+        </receiver>
     </application>
 
 </manifest>

--- a/app/src/androidMain/kotlin/de/dbauer/expensetracker/widget/UpcomingPaymentsWidget.kt
+++ b/app/src/androidMain/kotlin/de/dbauer/expensetracker/widget/UpcomingPaymentsWidget.kt
@@ -1,0 +1,103 @@
+package de.dbauer.expensetracker.widget
+
+import android.content.Context
+import android.os.Build
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.unit.dp
+import androidx.glance.GlanceId
+import androidx.glance.GlanceModifier
+import androidx.glance.GlanceTheme
+import androidx.glance.ImageProvider
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.components.Scaffold
+import androidx.glance.appwidget.components.TitleBar
+import androidx.glance.appwidget.lazy.GridCells
+import androidx.glance.appwidget.lazy.LazyVerticalGrid
+import androidx.glance.appwidget.lazy.items
+import androidx.glance.appwidget.provideContent
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Column
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.padding
+import androidx.glance.text.Text
+import androidx.glance.text.TextAlign
+import androidx.glance.text.TextStyle
+import asString
+import data.UpcomingPaymentData
+import de.dbauer.expensetracker.R
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import recurringexpensetracker.app.generated.resources.Res
+import recurringexpensetracker.app.generated.resources.upcoming_title
+
+class UpcomingPaymentsWidget : GlanceAppWidget(), KoinComponent {
+    private val upcomingPayment by inject<UpcomingPaymentsWidgetModel>()
+
+    override suspend fun provideGlance(
+        context: Context,
+        id: GlanceId,
+    ) {
+        val upcomingPaymentsTitle = Res.string.upcoming_title.asString()
+
+        provideContent {
+            LaunchedEffect(Unit) {
+                upcomingPayment.init()
+            }
+            GlanceTheme {
+                Scaffold(
+                    modifier = GlanceModifier.fillMaxSize(),
+                    titleBar = {
+                        TitleBar(
+                            startIcon = ImageProvider(R.mipmap.ic_launcher_monochrome),
+                            title = upcomingPaymentsTitle,
+                        )
+                    },
+                ) {
+                    StaggeredLazyVerticalGrid(
+                        items = upcomingPayment.upcomingPaymentsData,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun StaggeredLazyVerticalGrid(
+    items: List<UpcomingPaymentData>,
+    modifier: GlanceModifier = GlanceModifier,
+    gridMode: Boolean = true,
+) {
+    LazyVerticalGrid(
+        gridCells =
+            if (gridMode && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                GridCells.Adaptive(160.dp)
+            } else {
+                GridCells.Fixed(1)
+            },
+        modifier = modifier.fillMaxSize(),
+    ) {
+        items(items = items, itemId = { it.id.toLong() }) { item ->
+            Column(
+                modifier = GlanceModifier.padding(8.dp),
+                verticalAlignment = Alignment.Vertical.CenterVertically,
+            ) {
+                Text(
+                    text = item.name,
+                    maxLines = 1,
+                    style = TextStyle(GlanceTheme.colors.onSurface, textAlign = TextAlign.Center),
+                )
+                Text(
+                    text = item.price.toCurrencyString(),
+                    style = TextStyle(GlanceTheme.colors.onSurface, textAlign = TextAlign.Center),
+                )
+                Text(
+                    text = item.nextPaymentDate,
+                    maxLines = 2,
+                    style = TextStyle(GlanceTheme.colors.onSurface, textAlign = TextAlign.Center),
+                )
+            }
+        }
+    }
+}

--- a/app/src/androidMain/kotlin/de/dbauer/expensetracker/widget/UpcomingPaymentsWidget.kt
+++ b/app/src/androidMain/kotlin/de/dbauer/expensetracker/widget/UpcomingPaymentsWidget.kt
@@ -30,6 +30,7 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import recurringexpensetracker.app.generated.resources.Res
 import recurringexpensetracker.app.generated.resources.upcoming_title
+import ui.theme.widget.ExpenseTrackerWidgetTheme
 
 class UpcomingPaymentsWidget : GlanceAppWidget(), KoinComponent {
     private val upcomingPayment by inject<UpcomingPaymentsWidgetModel>()
@@ -44,7 +45,7 @@ class UpcomingPaymentsWidget : GlanceAppWidget(), KoinComponent {
             LaunchedEffect(Unit) {
                 upcomingPayment.init()
             }
-            GlanceTheme {
+            ExpenseTrackerWidgetTheme {
                 Scaffold(
                     modifier = GlanceModifier.fillMaxSize(),
                     titleBar = {

--- a/app/src/androidMain/kotlin/de/dbauer/expensetracker/widget/UpcomingPaymentsWidgetModel.kt
+++ b/app/src/androidMain/kotlin/de/dbauer/expensetracker/widget/UpcomingPaymentsWidgetModel.kt
@@ -1,14 +1,10 @@
-package viewmodel
+package de.dbauer.expensetracker.widget
 
 import androidx.compose.runtime.mutableStateListOf
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import data.CurrencyValue
-import data.RecurringExpenseData
 import data.UpcomingPaymentData
 import getDefaultCurrencyCode
 import getNextPaymentDays
-import kotlinx.coroutines.launch
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
@@ -22,33 +18,19 @@ import model.database.UserPreferencesRepository
 import toLocaleString
 import ui.customizations.ExpenseColor
 
-class UpcomingPaymentsViewModel(
+class UpcomingPaymentsWidgetModel(
     private val expenseRepository: ExpenseRepository,
     userPreferencesRepository: UserPreferencesRepository,
-) : ViewModel() {
+) {
     private val _upcomingPaymentsData = mutableStateListOf<UpcomingPaymentData>()
     val upcomingPaymentsData: List<UpcomingPaymentData>
         get() = _upcomingPaymentsData
 
     private val defaultCurrency = userPreferencesRepository.defaultCurrency.get()
 
-    init {
-        viewModelScope.launch {
-            expenseRepository.allRecurringExpensesByPrice.collect { recurringExpenses ->
-                onDatabaseUpdated(recurringExpenses)
-            }
-        }
-    }
-
-    fun onExpenseWithIdClicked(
-        expenceId: Int,
-        onItemClicked: (RecurringExpenseData) -> Unit,
-    ) {
-        viewModelScope.launch {
-            expenseRepository.getRecurringExpenseById(expenceId)?.let {
-                val recurringExpenseData = it.toFrontendType(defaultCurrency.getDefaultCurrencyCode())
-                onItemClicked(recurringExpenseData)
-            }
+    suspend fun init() {
+        expenseRepository.allRecurringExpensesByPrice.collect { recurringExpenses ->
+            onDatabaseUpdated(recurringExpenses)
         }
     }
 

--- a/app/src/androidMain/kotlin/de/dbauer/expensetracker/widget/UpcomingPaymentsWidgetReceiver.kt
+++ b/app/src/androidMain/kotlin/de/dbauer/expensetracker/widget/UpcomingPaymentsWidgetReceiver.kt
@@ -1,0 +1,8 @@
+package de.dbauer.expensetracker.widget
+
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+
+class UpcomingPaymentsWidgetReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = UpcomingPaymentsWidget()
+}

--- a/app/src/androidMain/kotlin/di/Module.android.kt
+++ b/app/src/androidMain/kotlin/di/Module.android.kt
@@ -7,6 +7,7 @@ import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStoreFile
 import androidx.room.RoomDatabase
+import de.dbauer.expensetracker.widget.UpcomingPaymentsWidgetModel
 import model.database.RecurringExpenseDatabase
 import model.database.UserPreferencesRepository
 import model.database.getDatabaseBuilder
@@ -24,4 +25,5 @@ actual val platformModule =
             }
         }
         singleOf(::UserPreferencesRepository)
+        singleOf(::UpcomingPaymentsWidgetModel)
     }

--- a/app/src/androidMain/kotlin/ui/theme/widget/ExpenseTrackerWidgetTheme.kt
+++ b/app/src/androidMain/kotlin/ui/theme/widget/ExpenseTrackerWidgetTheme.kt
@@ -1,0 +1,27 @@
+package ui.theme.widget
+
+import android.os.Build
+import androidx.compose.runtime.Composable
+import androidx.glance.GlanceTheme
+import androidx.glance.material3.ColorProviders
+import ui.theme.darkColorScheme
+import ui.theme.lightColorScheme
+
+@Composable
+fun ExpenseTrackerWidgetTheme(
+    dynamicColor: Boolean = true,
+    content: @Composable () -> Unit,
+) {
+    GlanceTheme(
+        colors =
+            if (dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                GlanceTheme.colors
+            } else {
+                ColorProviders(
+                    light = lightColorScheme,
+                    dark = darkColorScheme,
+                )
+            },
+        content = content,
+    )
+}

--- a/app/src/androidMain/res/values/dimen.xml
+++ b/app/src/androidMain/res/values/dimen.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="widget_min_height">128dp</dimen>
+    <dimen name="widget_min_width">128dp</dimen>
+    <dimen name="widget_min_resize_height">128dp</dimen>
+    <dimen name="widget_min_resize_width">128dp</dimen>
+    <dimen name="widget_max_resize_height">512dp</dimen>
+    <dimen name="widget_max_resize_width">512dp</dimen>
+
+    <integer name="widget_target_cell_height">2</integer>
+    <integer name="widget_target_cell_width">2</integer>
+    <integer name="widget_update_time">3000</integer>
+</resources>

--- a/app/src/androidMain/res/xml-v31/my_app_widget_info.xml
+++ b/app/src/androidMain/res/xml-v31/my_app_widget_info.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:resizeMode="horizontal|vertical"
+    android:updatePeriodMillis="@integer/widget_update_time"
+    android:minHeight="@dimen/widget_min_height"
+    android:minWidth="@dimen/widget_min_width"
+
+    android:minResizeHeight="@dimen/widget_min_resize_height"
+    android:minResizeWidth="@dimen/widget_min_resize_width"
+    android:maxResizeHeight="@dimen/widget_max_resize_height"
+    android:maxResizeWidth="@dimen/widget_max_resize_width"
+    android:targetCellHeight="@integer/widget_target_cell_height"
+    android:targetCellWidth="@integer/widget_target_cell_width"
+    android:initialLayout="@layout/glance_default_loading_layout">
+</appwidget-provider>

--- a/app/src/androidMain/res/xml/my_app_widget_info.xml
+++ b/app/src/androidMain/res/xml/my_app_widget_info.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:resizeMode="horizontal|vertical"
+    android:updatePeriodMillis="@integer/widget_update_time"
+    android:minHeight="@dimen/widget_min_height"
+    android:minWidth="@dimen/widget_min_width"
+
+    android:minResizeHeight="@dimen/widget_min_resize_height"
+    android:minResizeWidth="@dimen/widget_min_resize_width"
+    android:initialLayout="@layout/glance_default_loading_layout">
+</appwidget-provider>

--- a/app/src/commonMain/kotlin/Extensions.kt
+++ b/app/src/commonMain/kotlin/Extensions.kt
@@ -1,5 +1,10 @@
 import androidx.compose.ui.Modifier
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import model.DateTimeCalculator
+import model.getSystemCurrencyCode
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.getString
 
@@ -24,4 +29,12 @@ expect fun Instant.toLocaleString(): String
 
 suspend fun StringResource.asString(): String {
     return getString(this)
+}
+
+fun LocalDate.getNextPaymentDays(): Int {
+    return DateTimeCalculator.getDaysFromNowUntil(this)
+}
+
+suspend fun Flow<String>.getDefaultCurrencyCode(): String {
+    return first().ifBlank { getSystemCurrencyCode() }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ androidx-navigation-compose = "2.8.0-alpha12"
 androidx-test-junit = "1.2.1"
 biometric = "1.1.0"
 compose-plugin = "1.7.3"
+glance = "1.1.1"
 koin = "4.0.2"
 kotlin = "2.1.0"
 kotlinx-coroutines = "1.10.1"
@@ -28,6 +29,8 @@ androidx-activity-compose = { module = "androidx.activity:activity-compose", ver
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidx-appcompat" }
 androidx-biometric = { module = "androidx.biometric:biometric", version.ref = "biometric" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "androidx-datastore-preferences" }
+androidx-glance-appwidget = { module = "androidx.glance:glance-appwidget", version.ref = "glance" }
+androidx-glance-material3 = { module = "androidx.glance:glance-material3", version.ref = "glance" }
 androidx-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel", version.ref = "androidx-lifecycle-viewmodel" }
 androidx-navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "androidx-navigation-compose" }
 androidx-test-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-junit" }


### PR DESCRIPTION
Add Glance dependency, export common Res strings
The common Res strings are added as sourceSets and can be imported but
when using them in non common Code it gives a compile error that it
can not find them. Exposing them as public solves this.

Add basic Glance Widget
This adds a Widget using jetpack compose glance instead of xml.
This is the basic implementation updating the Widget does not work jet.
Replicating the common UpcomingPaymentsViewModel as with glance we can't
use ViewModels. Also we only have a small amount of basic composables
there is no e.g. Card with this reducing the information and style shown
in the Widget to a minimum.
The configuration of the Widget is also not yet there but prepared to be
also able to use Grid or List mode.

Configure Glance Theme