### PR TITLE
Add setting to show original currency of expenses

### DIFF
--- a/app/src/commonMain/composeResources/values-de/strings.xml
+++ b/app/src/commonMain/composeResources/values-de/strings.xml
@@ -54,6 +54,7 @@
     <string name="settings_system_default">Systemstandard</string>
     <string name="settings_currency_exchange_info">Ausgaben in einer anderen Währung werden in diese Währung umgerechnet.\nDie Wechselkurse sind mit der App fest eingegeben, um zu verhindern, dass sie auf das Internet zugreifen muss.</string>
     <string name="settings_currency_exchange_last_update">Wechselkurse vom %1$s</string>
+    <string name="settings_show_converted_currency">Umgerechnete Währung anzeigen</string>
     <string name="settings_backup">Sicherung</string>
     <string name="settings_backup_create">Sicherung erstellen</string>
     <string name="settings_backup_restore">Sicherung Wiederherstellen</string>

--- a/app/src/commonMain/composeResources/values/strings.xml
+++ b/app/src/commonMain/composeResources/values/strings.xml
@@ -56,6 +56,7 @@
     <string name="settings_system_default">System default</string>
     <string name="settings_currency_exchange_info">Expenses added in a different currency will be converted to that currency.\nThe exchange rates are bundled with the app to prevent it from accessing the Internet.</string>
     <string name="settings_currency_exchange_last_update">Change rates from %1$s</string>
+    <string name="settings_show_converted_currency">Show converted currency</string>
     <string name="settings_backup">Backup</string>
     <string name="settings_backup_create">Create backup</string>
     <string name="settings_backup_restore">Restore backup</string>

--- a/app/src/commonMain/kotlin/model/database/UserPreferencesRepository.kt
+++ b/app/src/commonMain/kotlin/model/database/UserPreferencesRepository.kt
@@ -47,6 +47,7 @@ class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) {
     val gridMode = Preference(booleanPreferencesKey("IS_GRID_MODE"), false)
     val biometricSecurity = Preference(booleanPreferencesKey("BIOMETRIC_SECURITY"), false)
     val defaultCurrency = Preference(stringPreferencesKey("DEFAULT_CURRENCY"), "")
+    val showConvertedCurrency = Preference(booleanPreferencesKey("SHOW_CONVERTED_CURRENCY"), true)
     val upcomingPaymentNotification = Preference(booleanPreferencesKey("IS_UPCOMING_PAYMENT_NOTIFICATION"), false)
 
     // default: 8:00 in the morning

--- a/app/src/commonMain/kotlin/ui/settings/SettingsClickableElementWithToggle.kt
+++ b/app/src/commonMain/kotlin/ui/settings/SettingsClickableElementWithToggle.kt
@@ -42,7 +42,7 @@ fun SettingsClickableElementWithToggle(
         Column(
             modifier =
                 Modifier
-                    .padding(start = 16.dp)
+                    .padding(horizontal = 16.dp)
                     .weight(1f),
         ) {
             Text(

--- a/app/src/commonMain/kotlin/ui/settings/SettingsMainScreen.kt
+++ b/app/src/commonMain/kotlin/ui/settings/SettingsMainScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.AttachMoney
 import androidx.compose.material.icons.rounded.Backup
 import androidx.compose.material.icons.rounded.CurrencyExchange
 import androidx.compose.material.icons.rounded.DateRange
@@ -50,6 +51,7 @@ import recurringexpensetracker.app.generated.resources.settings_notifications_sc
 import recurringexpensetracker.app.generated.resources.settings_notifications_subtitle
 import recurringexpensetracker.app.generated.resources.settings_notifications_upcoming
 import recurringexpensetracker.app.generated.resources.settings_security_biometric_lock
+import recurringexpensetracker.app.generated.resources.settings_show_converted_currency
 import recurringexpensetracker.app.generated.resources.settings_system_default
 import recurringexpensetracker.app.generated.resources.settings_title_security
 import ui.elements.TimePickerDialog
@@ -88,7 +90,13 @@ fun SettingsMainScreen(
                     stringResource(Res.string.settings_system_default)
                 },
             onClick = onClickDefaultCurrency,
+            icon = Icons.Rounded.AttachMoney,
+        )
+        SettingsClickableElementWithToggle(
+            title = stringResource(Res.string.settings_show_converted_currency),
+            checked = viewModel.showConvertedCurrency.collectAsState().value,
             icon = Icons.Rounded.CurrencyExchange,
+            onCheckedChange = viewModel::onShowConvertedCurrency,
         )
 
         if (canUseBiometric) {

--- a/app/src/commonMain/kotlin/viewmodel/SettingsViewModel.kt
+++ b/app/src/commonMain/kotlin/viewmodel/SettingsViewModel.kt
@@ -28,6 +28,7 @@ class SettingsViewModel(
         private set
     var exchangeRateLastUpdate by mutableStateOf("--")
         private set
+    val showConvertedCurrency = userPreferencesRepository.showConvertedCurrency
     val upcomingPaymentNotification = userPreferencesRepository.upcomingPaymentNotification
     var upcomingPaymentNotificationTime = userPreferencesRepository.upcomingPaymentNotificationTime
     var upcomingPaymentNotificationTimePickerDialog by mutableStateOf(false)
@@ -57,6 +58,12 @@ class SettingsViewModel(
     fun onCurrencySelected(currency: Currency?) {
         viewModelScope.launch {
             userPreferencesRepository.defaultCurrency.save(currency?.code ?: "")
+        }
+    }
+
+    fun onShowConvertedCurrency(convertExpenses: Boolean) {
+        viewModelScope.launch {
+            showConvertedCurrency.save(convertExpenses)
         }
     }
 


### PR DESCRIPTION
Depending on the setting either the original currency or the converted currency is shown in the home and upcoming tab.

fixes: #405