### PR TITLE
Fix a bug where upcoming expenses were only listed once each month

### DIFF
--- a/app/src/commonMain/kotlin/ui/upcomingexpenses/UpcomingPaymentsScreen.kt
+++ b/app/src/commonMain/kotlin/ui/upcomingexpenses/UpcomingPaymentsScreen.kt
@@ -120,7 +120,7 @@ private fun UpcomingPaymentsOverview(
             items(
                 items = upcomingPaymentsData,
                 key = { entry ->
-                    "expense_${entry.month}_${entry.payment?.id}"
+                    "expense_${entry.month}_${entry.payment?.id}_${entry.payment?.nextPaymentDate}"
                 },
                 span = { entry ->
                     if (entry.payment == null) {


### PR DESCRIPTION
When an expense occurred more than once a month only the first recurrence was listed. Now all recurrences should be shown.