### PR TITLE
Fix immediate crash in release configuration

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -23,3 +23,4 @@
 -dontwarn kotlinx.serialization.internal.AbstractPolymorphicSerializer
 
 -keep class * extends androidx.room.RoomDatabase { <init>(); }
+-keep class androidx.datastore.*.** { *; }


### PR DESCRIPTION
This issue was introduced in DataStore version 1.1.6 See: https://github.com/DennisBauer/RecurringExpenseTracker/pull/508

fixes: #524 