### PR TITLE
Fix empty upcoming payments tab on some time zones

### DIFF
--- a/app/src/commonMain/kotlin/model/DateTimeCalculator.kt
+++ b/app/src/commonMain/kotlin/model/DateTimeCalculator.kt
@@ -1,5 +1,6 @@
 package model
 
+import androidx.annotation.VisibleForTesting
 import kotlinx.datetime.Clock
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.Instant
@@ -12,16 +13,7 @@ import kotlinx.datetime.toLocalDateTime
 
 object DateTimeCalculator {
     fun getDaysFromNowUntil(until: LocalDate): Int {
-        return getDaysFromUntil(Clock.System.now(), until)
-    }
-
-    fun getDaysFromUntil(
-        from: Instant,
-        until: LocalDate,
-        fromTimeZone: TimeZone = TimeZone.currentSystemDefault(),
-    ): Int {
-        val fromStartOfDay = from.toLocalDateTime(fromTimeZone).date.atStartOfDayIn(TimeZone.UTC)
-        return fromStartOfDay.daysUntil(until.atStartOfDayIn(TimeZone.UTC), TimeZone.UTC)
+        return getDaysFromUntil(getCurrentLocalDate(), until)
     }
 
     fun getDaysFromUntil(
@@ -37,23 +29,28 @@ object DateTimeCalculator {
         everyXRecurrence: Int,
         recurrence: DateTimeUnit.DateBased,
     ): LocalDate {
-        return getDayOfNextOccurrence(Clock.System.now(), from, everyXRecurrence, recurrence)
+        return getDayOfNextOccurrence(getCurrentLocalDate(), from, everyXRecurrence, recurrence)
     }
 
     fun getDayOfNextOccurrence(
-        atPointInTime: Instant,
+        afterDay: LocalDate,
         first: Instant,
         everyXRecurrence: Int,
         recurrence: DateTimeUnit.DateBased,
-        atPointInTimeZone: TimeZone = TimeZone.currentSystemDefault(),
     ): LocalDate {
-        val pointInTime = atPointInTime.toLocalDateTime(atPointInTimeZone).date
         var nextOccurrence = first.toLocalDateTime(TimeZone.UTC).date
 
-        while (pointInTime.isInDaysAfter(nextOccurrence) && !pointInTime.isSameDay(nextOccurrence)) {
+        while (afterDay.isInDaysAfter(nextOccurrence) && !afterDay.isSameDay(nextOccurrence)) {
             nextOccurrence = nextOccurrence.plus(everyXRecurrence, recurrence)
         }
         return nextOccurrence
+    }
+
+    fun getCurrentLocalDate(
+        @VisibleForTesting
+        now: Instant = Clock.System.now(),
+    ): LocalDate {
+        return now.toLocalDateTime(TimeZone.currentSystemDefault()).date
     }
 
     private fun LocalDate.isSameDay(other: LocalDate): Boolean {

--- a/app/src/commonMain/kotlin/model/database/RecurringExpense.kt
+++ b/app/src/commonMain/kotlin/model/database/RecurringExpense.kt
@@ -6,8 +6,6 @@ import androidx.room.PrimaryKey
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.atStartOfDayIn
 import model.DateTimeCalculator
 
 @Entity(tableName = "recurring_expenses")
@@ -59,7 +57,7 @@ data class RecurringExpense(
         if (everyXRecurrence == null) return null
 
         return DateTimeCalculator.getDayOfNextOccurrence(
-            atPointInTime = afterDate.atStartOfDayIn(TimeZone.UTC),
+            afterDay = afterDate,
             first = Instant.fromEpochMilliseconds(firstPayment),
             everyXRecurrence = everyXRecurrence,
             recurrence = recurrence.toDateTimeUnit(),

--- a/app/src/commonTest/kotlin/model/DateTimeCalculatorTest.kt
+++ b/app/src/commonTest/kotlin/model/DateTimeCalculatorTest.kt
@@ -10,107 +10,16 @@ import kotlin.test.assertEquals
 
 class DateTimeCalculatorTest {
     @Test
-    fun checkDayCalculationWorksFromAnyTimeOfDay() {
-        val expected = 1
+    fun checkGetCurrentLocalDateWorksFromAnyTimeOfDay() {
+        val expected = LocalDate(2024, 7, 21)
 
         for (hour in 0..23) {
             val actual =
-                DateTimeCalculator.getDaysFromUntil(
-                    from = LocalDateTime(2024, 7, 21, hour, 0, 7, 10).toInstant(TimeZone.currentSystemDefault()),
-                    until = LocalDate(2024, 7, 22),
+                DateTimeCalculator.getCurrentLocalDate(
+                    now = LocalDateTime(2024, 7, 21, hour, 0, 7, 10).toInstant(TimeZone.currentSystemDefault()),
                 )
 
             assertEquals(expected, actual, "Failed the data calculation didn't work using hour $hour")
-        }
-    }
-
-    @Test
-    fun checkDayCalculationFromDifferentTimeZones() {
-        val expected = 34
-
-        listOf(
-            TimeZone.of("America/New_York"),
-            TimeZone.of("Pacific/Midway"),
-            TimeZone.of("Asia/Tokyo"),
-        ).forEach { timeZone ->
-            var actual =
-                DateTimeCalculator.getDaysFromUntil(
-                    from = LocalDateTime(2024, 6, 18, 0, 0, 7, 10).toInstant(timeZone),
-                    until = LocalDate(2024, 7, 22),
-                    fromTimeZone = timeZone,
-                )
-            assertEquals(expected, actual)
-
-            actual =
-                DateTimeCalculator.getDaysFromUntil(
-                    from = LocalDateTime(2024, 6, 18, 23, 0, 7, 10).toInstant(timeZone),
-                    until = LocalDate(2024, 7, 22),
-                    fromTimeZone = timeZone,
-                )
-
-            assertEquals(expected, actual, "Failed the data calculation didn't work using time zone: $timeZone")
-        }
-    }
-
-    @Test
-    fun checkDayOfNextOccurrenceFromAnyTimeOfDay() {
-        val expected = LocalDate(2024, 7, 12)
-
-        for (hour in 0..23) {
-            val actual =
-                DateTimeCalculator.getDayOfNextOccurrence(
-                    atPointInTime =
-                        LocalDateTime(2024, 7, 1, hour, 0, 7, 10)
-                            .toInstant(TimeZone.currentSystemDefault()),
-                    first =
-                        LocalDateTime(2024, 5, 12, 0, 0, 0, 0)
-                            .toInstant(TimeZone.UTC),
-                    everyXRecurrence = 1,
-                    recurrence = DateTimeUnit.MONTH,
-                )
-
-            assertEquals(expected, actual, "Failed the data calculation didn't work using hour $hour")
-        }
-    }
-
-    @Test
-    fun checkDayOfNextOccurrenceFromDifferentTimeZones() {
-        val expected = LocalDate(2024, 6, 1)
-
-        listOf(
-            TimeZone.of("America/New_York"),
-            TimeZone.of("Pacific/Midway"),
-            TimeZone.of("Asia/Tokyo"),
-        ).forEach { timeZone ->
-            var actual =
-                DateTimeCalculator.getDayOfNextOccurrence(
-                    atPointInTime =
-                        LocalDateTime(2024, 5, 29, 0, 0, 7, 10)
-                            .toInstant(timeZone),
-                    first =
-                        LocalDateTime(2023, 11, 1, 0, 0, 0, 0)
-                            .toInstant(TimeZone.UTC),
-                    everyXRecurrence = 1,
-                    recurrence = DateTimeUnit.MONTH,
-                    atPointInTimeZone = timeZone,
-                )
-
-            assertEquals(expected, actual, "Failed the data calculation didn't work using time zone: $timeZone")
-
-            actual =
-                DateTimeCalculator.getDayOfNextOccurrence(
-                    atPointInTime =
-                        LocalDateTime(2024, 5, 29, 0, 0, 7, 10)
-                            .toInstant(timeZone),
-                    first =
-                        LocalDateTime(2023, 11, 1, 0, 0, 0, 0)
-                            .toInstant(TimeZone.UTC),
-                    everyXRecurrence = 1,
-                    recurrence = DateTimeUnit.MONTH,
-                    atPointInTimeZone = timeZone,
-                )
-
-            assertEquals(expected, actual, "Failed the data calculation didn't work using time zone: $timeZone")
         }
     }
 
@@ -119,9 +28,7 @@ class DateTimeCalculatorTest {
         var expected = LocalDate(2024, 5, 25)
         var actual =
             DateTimeCalculator.getDayOfNextOccurrence(
-                atPointInTime =
-                    LocalDateTime(2024, 5, 25, 1, 0, 7, 10)
-                        .toInstant(TimeZone.currentSystemDefault()),
+                afterDay = LocalDate(2024, 5, 25),
                 first =
                     LocalDateTime(2024, 4, 30, 0, 0, 0, 0)
                         .toInstant(TimeZone.UTC),
@@ -133,9 +40,7 @@ class DateTimeCalculatorTest {
         expected = LocalDate(2024, 5, 25)
         actual =
             DateTimeCalculator.getDayOfNextOccurrence(
-                atPointInTime =
-                    LocalDateTime(2024, 5, 24, 1, 0, 7, 10)
-                        .toInstant(TimeZone.currentSystemDefault()),
+                afterDay = LocalDate(2024, 5, 24),
                 first =
                     LocalDateTime(2024, 4, 30, 0, 0, 0, 0)
                         .toInstant(TimeZone.UTC),
@@ -150,9 +55,7 @@ class DateTimeCalculatorTest {
         var expected = LocalDate(2024, 6, 20)
         var actual =
             DateTimeCalculator.getDayOfNextOccurrence(
-                atPointInTime =
-                    LocalDateTime(2024, 6, 14, 1, 0, 7, 10)
-                        .toInstant(TimeZone.currentSystemDefault()),
+                afterDay = LocalDate(2024, 6, 14),
                 first =
                     LocalDateTime(2024, 5, 2, 0, 0, 0, 0)
                         .toInstant(TimeZone.UTC),
@@ -164,9 +67,7 @@ class DateTimeCalculatorTest {
         expected = LocalDate(2024, 6, 27)
         actual =
             DateTimeCalculator.getDayOfNextOccurrence(
-                atPointInTime =
-                    LocalDateTime(2024, 6, 14, 1, 0, 7, 10)
-                        .toInstant(TimeZone.currentSystemDefault()),
+                afterDay = LocalDate(2024, 6, 14),
                 first =
                     LocalDateTime(2024, 5, 2, 0, 0, 0, 0)
                         .toInstant(TimeZone.UTC),
@@ -182,9 +83,7 @@ class DateTimeCalculatorTest {
         var expected = LocalDate(2024, 2, 29)
         var actual =
             DateTimeCalculator.getDayOfNextOccurrence(
-                atPointInTime =
-                    LocalDateTime(2024, 2, 28, 1, 0, 7, 10)
-                        .toInstant(TimeZone.currentSystemDefault()),
+                afterDay = LocalDate(2024, 2, 28),
                 first =
                     LocalDateTime(2024, 1, 30, 0, 0, 0, 0)
                         .toInstant(TimeZone.UTC),
@@ -196,9 +95,7 @@ class DateTimeCalculatorTest {
         expected = LocalDate(2024, 6, 15)
         actual =
             DateTimeCalculator.getDayOfNextOccurrence(
-                atPointInTime =
-                    LocalDateTime(2024, 6, 15, 1, 0, 7, 10)
-                        .toInstant(TimeZone.currentSystemDefault()),
+                afterDay = LocalDate(2024, 6, 15),
                 first =
                     LocalDateTime(2023, 12, 15, 0, 0, 0, 0)
                         .toInstant(TimeZone.UTC),
@@ -210,9 +107,7 @@ class DateTimeCalculatorTest {
         expected = LocalDate(2024, 6, 15)
         actual =
             DateTimeCalculator.getDayOfNextOccurrence(
-                atPointInTime =
-                    LocalDateTime(2024, 5, 16, 1, 0, 7, 10)
-                        .toInstant(TimeZone.currentSystemDefault()),
+                afterDay = LocalDate(2024, 5, 16),
                 first =
                     LocalDateTime(2023, 12, 15, 0, 0, 0, 0)
                         .toInstant(TimeZone.UTC),
@@ -227,9 +122,7 @@ class DateTimeCalculatorTest {
         var expected = LocalDate(2024, 6, 1)
         var actual =
             DateTimeCalculator.getDayOfNextOccurrence(
-                atPointInTime =
-                    LocalDateTime(2024, 5, 29, 23, 0, 7, 10)
-                        .toInstant(TimeZone.currentSystemDefault()),
+                afterDay = LocalDate(2024, 5, 29),
                 first =
                     LocalDateTime(2023, 6, 1, 0, 0, 0, 0)
                         .toInstant(TimeZone.UTC),
@@ -241,9 +134,7 @@ class DateTimeCalculatorTest {
         expected = LocalDate(2026, 6, 1)
         actual =
             DateTimeCalculator.getDayOfNextOccurrence(
-                atPointInTime =
-                    LocalDateTime(2024, 6, 2, 1, 0, 7, 10)
-                        .toInstant(TimeZone.currentSystemDefault()),
+                afterDay = LocalDate(2024, 6, 2),
                 first =
                     LocalDateTime(2022, 6, 1, 0, 0, 0, 0)
                         .toInstant(TimeZone.UTC),


### PR DESCRIPTION
Fix a problem with made the calculation of the upcoming expenses run into infinity and by that show nothing on the upcoming payments tab. Simplify the calculation by reducing the forth and back calculation from
 Instant to LocalDate.

fixes: #528