### PR TITLE
Remove SQLite Bundled from common code

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -81,7 +81,6 @@ kotlin {
 
             implementation(libs.aboutlibraries.compose.m3)
             implementation(libs.room.runtime)
-            implementation(libs.sqlite.bundled)
 
             implementation(project.dependencies.platform(libs.koin.bom))
             api(libs.koin.core)
@@ -91,6 +90,10 @@ kotlin {
         jvmMain.dependencies {
             implementation(compose.desktop.currentOs)
             implementation(libs.kotlinx.coroutines.swing)
+            implementation(libs.sqlite.bundled)
+        }
+        iosMain.dependencies {
+            implementation(libs.sqlite.bundled)
         }
 
         commonTest.dependencies {

--- a/app/src/commonMain/kotlin/de/dbauer/expensetracker/model/database/RecurringExpenseDatabase.kt
+++ b/app/src/commonMain/kotlin/de/dbauer/expensetracker/model/database/RecurringExpenseDatabase.kt
@@ -6,7 +6,6 @@ import androidx.room.RoomDatabase
 import androidx.room.RoomDatabaseConstructor
 import androidx.room.migration.Migration
 import androidx.sqlite.SQLiteConnection
-import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import androidx.sqlite.execSQL
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
@@ -40,7 +39,6 @@ abstract class RecurringExpenseDatabase : RoomDatabase() {
                 .addMigrations(migration_6_7)
                 .addMigrations(migration_7_8)
                 .fallbackToDestructiveMigrationOnDowngrade(true)
-                .setDriver(BundledSQLiteDriver())
                 .setQueryCoroutineContext(Dispatchers.IO)
                 .build()
         }

--- a/app/src/iosMain/kotlin/de/dbauer/expensetracker/model/database/GetDatabaseBuilder.kt
+++ b/app/src/iosMain/kotlin/de/dbauer/expensetracker/model/database/GetDatabaseBuilder.kt
@@ -3,6 +3,7 @@ package de.dbauer.expensetracker.model.database
 import Constants
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.Foundation.NSDocumentDirectory
 import platform.Foundation.NSFileManager
@@ -10,9 +11,10 @@ import platform.Foundation.NSUserDomainMask
 
 fun getDatabaseBuilder(): RoomDatabase.Builder<RecurringExpenseDatabase> {
     val dbFilePath = "${documentDirectory()}/${Constants.DATABASE_NAME}"
-    return Room.databaseBuilder<RecurringExpenseDatabase>(
-        name = dbFilePath,
-    )
+    return Room
+        .databaseBuilder<RecurringExpenseDatabase>(
+            name = dbFilePath,
+        ).setDriver(BundledSQLiteDriver())
 }
 
 @OptIn(ExperimentalForeignApi::class)

--- a/app/src/jvmMain/kotlin/de/dbauer/expensetracker/model/database/GetDatabaseBuilder.kt
+++ b/app/src/jvmMain/kotlin/de/dbauer/expensetracker/model/database/GetDatabaseBuilder.kt
@@ -3,11 +3,13 @@ package de.dbauer.expensetracker.model.database
 import Constants
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import java.io.File
 
 fun getDatabaseBuilder(): RoomDatabase.Builder<RecurringExpenseDatabase> {
     val dbFile = File(System.getProperty("java.io.tmpdir"), Constants.DATABASE_NAME)
-    return Room.databaseBuilder<RecurringExpenseDatabase>(
-        name = dbFile.absolutePath,
-    )
+    return Room
+        .databaseBuilder<RecurringExpenseDatabase>(
+            name = dbFile.absolutePath,
+        ).setDriver(BundledSQLiteDriver())
 }


### PR DESCRIPTION
Android doesn't need the SQLite bundled driver. Removing it from the common sources reduces the app size from by 2/3. Now it is only applied in the JVM and iOS source set.