### PR TITLE
Confirm back action on edit expense screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -75,6 +75,7 @@ kotlin {
             implementation(libs.androidx.lifecycle.viewmodel)
             implementation(libs.androidx.navigation.compose)
             implementation(libs.compose.colorpicker)
+            implementation(libs.compose.ui.backhandler)
             implementation(libs.kotlinx.datetime)
             implementation(libs.kotlinx.serialization.json)
 

--- a/app/src/commonMain/composeResources/values-de/strings.xml
+++ b/app/src/commonMain/composeResources/values-de/strings.xml
@@ -42,6 +42,8 @@
     <string name="edit_expense_notification_remove_reminder_content_desc">Erinnerung entfernen</string>
     <string name="edit_expense_notification_days_before_payment">%1$s Tage vor der Zahlung</string>
     <string name="edit_expense_delete_dialog_text">Möchtest du diese Ausgabe wirklich löschen?</string>
+    <string name="edit_expense_unsaved_changes_dialog_title">Ungespeicherte Änderungen</string>
+    <string name="edit_expense_unsaved_changes_dialog_text">Du hast ungespeicherte Änderungen. Möchtest du sie verwerfen?</string>
 
     <string name="tags_screen_title">Tags</string>
     <string name="tags_add_new">Neuen Tag erstellen</string>
@@ -119,6 +121,7 @@
     <string name="cancel">Abbrechen</string>
     <string name="delete">Löschen</string>
     <string name="save">Speichern</string>
+    <string name="discard">Verwerfen</string>
 
     <!-- Notifications -->
     <string name="notification_expense_reminder">Ausgabenerinnerung</string>

--- a/app/src/commonMain/composeResources/values/strings.xml
+++ b/app/src/commonMain/composeResources/values/strings.xml
@@ -44,6 +44,8 @@
     <string name="edit_expense_notification_remove_reminder_content_desc">Remove reminder</string>
     <string name="edit_expense_notification_days_before_payment">%1$s days before payment</string>
     <string name="edit_expense_delete_dialog_text">Do you really want to delete this expense?</string>
+    <string name="edit_expense_unsaved_changes_dialog_title">Unsaved Changes</string>
+    <string name="edit_expense_unsaved_changes_dialog_text">You have unsaved changes. Do you want to discard them?</string>
 
     <string name="tags_screen_title">Tags</string>
     <string name="tags_add_new">Add new Tag</string>
@@ -121,6 +123,7 @@
     <string name="cancel">Cancel</string>
     <string name="delete">Delete</string>
     <string name="save">Save</string>
+    <string name="discard">Discard</string>
 
     <!-- Notifications -->
     <string name="notification_expense_reminder">Expense Reminder</string>

--- a/app/src/commonTest/kotlin/de/dbauer/expensetracker/viewmodel/EditRecurringExpenseViewModelTest.kt
+++ b/app/src/commonTest/kotlin/de/dbauer/expensetracker/viewmodel/EditRecurringExpenseViewModelTest.kt
@@ -383,4 +383,527 @@ class EditRecurringExpenseViewModelTest {
             assertEquals(0, viewModel.reminders.size)
             assertFalse(viewModel.notifyForExpense)
         }
+
+    @Test
+    fun `new expense with no changes has no unsaved changes`() =
+        runTest {
+            val viewModel =
+                EditRecurringExpenseViewModel(
+                    expenseId = null,
+                    expenseRepository = expenseRepository,
+                    currencyProvider = currencyProvider,
+                    userPreferencesRepository = userPreferencesRepository,
+                )
+
+            advanceUntilIdle()
+
+            var dismissed = false
+            viewModel.onBackPressed { dismissed = true }
+
+            advanceUntilIdle()
+
+            // Should dismiss without showing dialog
+            assertTrue(dismissed)
+            assertFalse(viewModel.showDismissUnsavedChangesDialog)
+        }
+
+    @Test
+    fun `new expense with name entered has unsaved changes`() =
+        runTest {
+            val viewModel =
+                EditRecurringExpenseViewModel(
+                    expenseId = null,
+                    expenseRepository = expenseRepository,
+                    currencyProvider = currencyProvider,
+                    userPreferencesRepository = userPreferencesRepository,
+                )
+
+            advanceUntilIdle()
+
+            viewModel.nameState = "Netflix"
+
+            var dismissed = false
+            viewModel.onBackPressed { dismissed = true }
+
+            advanceUntilIdle()
+
+            // Should show dialog
+            assertFalse(dismissed)
+            assertTrue(viewModel.showDismissUnsavedChangesDialog)
+        }
+
+    @Test
+    fun `new expense with description entered has unsaved changes`() =
+        runTest {
+            val viewModel =
+                EditRecurringExpenseViewModel(
+                    expenseId = null,
+                    expenseRepository = expenseRepository,
+                    currencyProvider = currencyProvider,
+                    userPreferencesRepository = userPreferencesRepository,
+                )
+
+            advanceUntilIdle()
+
+            viewModel.descriptionState = "Streaming service"
+
+            var dismissed = false
+            viewModel.onBackPressed { dismissed = true }
+
+            advanceUntilIdle()
+
+            assertFalse(dismissed)
+            assertTrue(viewModel.showDismissUnsavedChangesDialog)
+        }
+
+    @Test
+    fun `new expense with price entered has unsaved changes`() =
+        runTest {
+            val viewModel =
+                EditRecurringExpenseViewModel(
+                    expenseId = null,
+                    expenseRepository = expenseRepository,
+                    currencyProvider = currencyProvider,
+                    userPreferencesRepository = userPreferencesRepository,
+                )
+
+            advanceUntilIdle()
+
+            viewModel.priceState = "9.99"
+
+            var dismissed = false
+            viewModel.onBackPressed { dismissed = true }
+
+            advanceUntilIdle()
+
+            assertFalse(dismissed)
+            assertTrue(viewModel.showDismissUnsavedChangesDialog)
+        }
+
+    @Test
+    fun `existing expense with no changes has no unsaved changes`() =
+        runTest {
+            val existingExpense =
+                RecurringExpenseData(
+                    id = 1,
+                    name = "Netflix",
+                    description = "Streaming",
+                    price = CurrencyValue(9.99f, "USD"),
+                    monthlyPrice = CurrencyValue(9.99f, "USD"),
+                    everyXRecurrence = 1,
+                    recurrence = Recurrence.Monthly,
+                    tags = emptyList(),
+                    firstPayment = null,
+                    notifyForExpense = true,
+                    reminders = listOf(Reminder(id = 1, daysBeforePayment = 3)),
+                )
+
+            expenseRepository.insert(existingExpense)
+
+            val viewModel =
+                EditRecurringExpenseViewModel(
+                    expenseId = 1,
+                    expenseRepository = expenseRepository,
+                    currencyProvider = currencyProvider,
+                    userPreferencesRepository = userPreferencesRepository,
+                )
+
+            advanceUntilIdle()
+
+            var dismissed = false
+            viewModel.onBackPressed { dismissed = true }
+
+            advanceUntilIdle()
+
+            // Should dismiss without showing dialog
+            assertTrue(dismissed)
+            assertFalse(viewModel.showDismissUnsavedChangesDialog)
+        }
+
+    @Test
+    fun `existing expense with changed name has unsaved changes`() =
+        runTest {
+            val existingExpense =
+                RecurringExpenseData(
+                    id = 1,
+                    name = "Netflix",
+                    description = "Streaming",
+                    price = CurrencyValue(9.99f, "USD"),
+                    monthlyPrice = CurrencyValue(9.99f, "USD"),
+                    everyXRecurrence = 1,
+                    recurrence = Recurrence.Monthly,
+                    tags = emptyList(),
+                    firstPayment = null,
+                    notifyForExpense = true,
+                    reminders = listOf(Reminder(id = 1, daysBeforePayment = 3)),
+                )
+
+            expenseRepository.insert(existingExpense)
+
+            val viewModel =
+                EditRecurringExpenseViewModel(
+                    expenseId = 1,
+                    expenseRepository = expenseRepository,
+                    currencyProvider = currencyProvider,
+                    userPreferencesRepository = userPreferencesRepository,
+                )
+
+            advanceUntilIdle()
+
+            viewModel.nameState = "Netflix Premium"
+
+            var dismissed = false
+            viewModel.onBackPressed { dismissed = true }
+
+            advanceUntilIdle()
+
+            assertFalse(dismissed)
+            assertTrue(viewModel.showDismissUnsavedChangesDialog)
+        }
+
+    @Test
+    fun `existing expense with changed price has unsaved changes`() =
+        runTest {
+            val existingExpense =
+                RecurringExpenseData(
+                    id = 1,
+                    name = "Netflix",
+                    description = "Streaming",
+                    price = CurrencyValue(9.99f, "USD"),
+                    monthlyPrice = CurrencyValue(9.99f, "USD"),
+                    everyXRecurrence = 1,
+                    recurrence = Recurrence.Monthly,
+                    tags = emptyList(),
+                    firstPayment = null,
+                    notifyForExpense = true,
+                    reminders = listOf(Reminder(id = 1, daysBeforePayment = 3)),
+                )
+
+            expenseRepository.insert(existingExpense)
+
+            val viewModel =
+                EditRecurringExpenseViewModel(
+                    expenseId = 1,
+                    expenseRepository = expenseRepository,
+                    currencyProvider = currencyProvider,
+                    userPreferencesRepository = userPreferencesRepository,
+                )
+
+            advanceUntilIdle()
+
+            viewModel.priceState = "12.99"
+
+            var dismissed = false
+            viewModel.onBackPressed { dismissed = true }
+
+            advanceUntilIdle()
+
+            assertFalse(dismissed)
+            assertTrue(viewModel.showDismissUnsavedChangesDialog)
+        }
+
+    @Test
+    fun `existing expense with changed recurrence has unsaved changes`() =
+        runTest {
+            val existingExpense =
+                RecurringExpenseData(
+                    id = 1,
+                    name = "Netflix",
+                    description = "Streaming",
+                    price = CurrencyValue(9.99f, "USD"),
+                    monthlyPrice = CurrencyValue(9.99f, "USD"),
+                    everyXRecurrence = 1,
+                    recurrence = Recurrence.Monthly,
+                    tags = emptyList(),
+                    firstPayment = null,
+                    notifyForExpense = true,
+                    reminders = listOf(Reminder(id = 1, daysBeforePayment = 3)),
+                )
+
+            expenseRepository.insert(existingExpense)
+
+            val viewModel =
+                EditRecurringExpenseViewModel(
+                    expenseId = 1,
+                    expenseRepository = expenseRepository,
+                    currencyProvider = currencyProvider,
+                    userPreferencesRepository = userPreferencesRepository,
+                )
+
+            advanceUntilIdle()
+
+            viewModel.selectedRecurrence = Recurrence.Yearly
+
+            var dismissed = false
+            viewModel.onBackPressed { dismissed = true }
+
+            advanceUntilIdle()
+
+            assertFalse(dismissed)
+            assertTrue(viewModel.showDismissUnsavedChangesDialog)
+        }
+
+    @Test
+    fun `existing expense with changed notification setting has unsaved changes`() =
+        runTest {
+            val existingExpense =
+                RecurringExpenseData(
+                    id = 1,
+                    name = "Netflix",
+                    description = "Streaming",
+                    price = CurrencyValue(9.99f, "USD"),
+                    monthlyPrice = CurrencyValue(9.99f, "USD"),
+                    everyXRecurrence = 1,
+                    recurrence = Recurrence.Monthly,
+                    tags = emptyList(),
+                    firstPayment = null,
+                    notifyForExpense = true,
+                    reminders = listOf(Reminder(id = 1, daysBeforePayment = 3)),
+                )
+
+            expenseRepository.insert(existingExpense)
+
+            val viewModel =
+                EditRecurringExpenseViewModel(
+                    expenseId = 1,
+                    expenseRepository = expenseRepository,
+                    currencyProvider = currencyProvider,
+                    userPreferencesRepository = userPreferencesRepository,
+                )
+
+            advanceUntilIdle()
+
+            viewModel.onNotifyForExpenseChange(false)
+
+            var dismissed = false
+            viewModel.onBackPressed { dismissed = true }
+
+            advanceUntilIdle()
+
+            assertFalse(dismissed)
+            assertTrue(viewModel.showDismissUnsavedChangesDialog)
+        }
+
+    @Test
+    fun `existing expense with added reminder has unsaved changes`() =
+        runTest {
+            val existingExpense =
+                RecurringExpenseData(
+                    id = 1,
+                    name = "Netflix",
+                    description = "Streaming",
+                    price = CurrencyValue(9.99f, "USD"),
+                    monthlyPrice = CurrencyValue(9.99f, "USD"),
+                    everyXRecurrence = 1,
+                    recurrence = Recurrence.Monthly,
+                    tags = emptyList(),
+                    firstPayment = null,
+                    notifyForExpense = true,
+                    reminders = listOf(Reminder(id = 1, daysBeforePayment = 3)),
+                )
+
+            expenseRepository.insert(existingExpense)
+
+            val viewModel =
+                EditRecurringExpenseViewModel(
+                    expenseId = 1,
+                    expenseRepository = expenseRepository,
+                    currencyProvider = currencyProvider,
+                    userPreferencesRepository = userPreferencesRepository,
+                )
+
+            advanceUntilIdle()
+
+            viewModel.addReminder(7)
+
+            var dismissed = false
+            viewModel.onBackPressed { dismissed = true }
+
+            advanceUntilIdle()
+
+            assertFalse(dismissed)
+            assertTrue(viewModel.showDismissUnsavedChangesDialog)
+        }
+
+    @Test
+    fun `existing expense with removed reminder has unsaved changes`() =
+        runTest {
+            val existingExpense =
+                RecurringExpenseData(
+                    id = 1,
+                    name = "Netflix",
+                    description = "Streaming",
+                    price = CurrencyValue(9.99f, "USD"),
+                    monthlyPrice = CurrencyValue(9.99f, "USD"),
+                    everyXRecurrence = 1,
+                    recurrence = Recurrence.Monthly,
+                    tags = emptyList(),
+                    firstPayment = null,
+                    notifyForExpense = true,
+                    reminders =
+                        listOf(
+                            Reminder(id = 1, daysBeforePayment = 3),
+                            Reminder(id = 2, daysBeforePayment = 7),
+                        ),
+                )
+
+            expenseRepository.insert(existingExpense)
+
+            val viewModel =
+                EditRecurringExpenseViewModel(
+                    expenseId = 1,
+                    expenseRepository = expenseRepository,
+                    currencyProvider = currencyProvider,
+                    userPreferencesRepository = userPreferencesRepository,
+                )
+
+            advanceUntilIdle()
+
+            viewModel.removeReminder(0)
+
+            var dismissed = false
+            viewModel.onBackPressed { dismissed = true }
+
+            advanceUntilIdle()
+
+            assertFalse(dismissed)
+            assertTrue(viewModel.showDismissUnsavedChangesDialog)
+        }
+
+    @Test
+    fun `existing expense with updated reminder has unsaved changes`() =
+        runTest {
+            val existingExpense =
+                RecurringExpenseData(
+                    id = 1,
+                    name = "Netflix",
+                    description = "Streaming",
+                    price = CurrencyValue(9.99f, "USD"),
+                    monthlyPrice = CurrencyValue(9.99f, "USD"),
+                    everyXRecurrence = 1,
+                    recurrence = Recurrence.Monthly,
+                    tags = emptyList(),
+                    firstPayment = null,
+                    notifyForExpense = true,
+                    reminders = listOf(Reminder(id = 1, daysBeforePayment = 3)),
+                )
+
+            expenseRepository.insert(existingExpense)
+
+            val viewModel =
+                EditRecurringExpenseViewModel(
+                    expenseId = 1,
+                    expenseRepository = expenseRepository,
+                    currencyProvider = currencyProvider,
+                    userPreferencesRepository = userPreferencesRepository,
+                )
+
+            advanceUntilIdle()
+
+            viewModel.updateReminder(0, 5)
+
+            var dismissed = false
+            viewModel.onBackPressed { dismissed = true }
+
+            advanceUntilIdle()
+
+            assertFalse(dismissed)
+            assertTrue(viewModel.showDismissUnsavedChangesDialog)
+        }
+
+    @Test
+    fun `onDismissUnsavedChangesDialog hides the dialog`() =
+        runTest {
+            val viewModel =
+                EditRecurringExpenseViewModel(
+                    expenseId = null,
+                    expenseRepository = expenseRepository,
+                    currencyProvider = currencyProvider,
+                    userPreferencesRepository = userPreferencesRepository,
+                )
+
+            advanceUntilIdle()
+
+            viewModel.nameState = "Test"
+            viewModel.onBackPressed { }
+
+            advanceUntilIdle()
+
+            assertTrue(viewModel.showDismissUnsavedChangesDialog)
+
+            viewModel.onDismissUnsavedChangesDialog()
+
+            assertFalse(viewModel.showDismissUnsavedChangesDialog)
+        }
+
+    @Test
+    fun `onDiscardChanges dismisses and calls callback`() =
+        runTest {
+            val viewModel =
+                EditRecurringExpenseViewModel(
+                    expenseId = null,
+                    expenseRepository = expenseRepository,
+                    currencyProvider = currencyProvider,
+                    userPreferencesRepository = userPreferencesRepository,
+                )
+
+            advanceUntilIdle()
+
+            viewModel.nameState = "Test"
+            viewModel.onBackPressed { }
+
+            advanceUntilIdle()
+
+            assertTrue(viewModel.showDismissUnsavedChangesDialog)
+
+            var dismissed = false
+            viewModel.onDiscardChanges { dismissed = true }
+
+            assertFalse(viewModel.showDismissUnsavedChangesDialog)
+            assertTrue(dismissed)
+        }
+
+    @Test
+    fun `existing expense with default reminder shown when DB has no reminders matches default`() =
+        runTest {
+            val existingExpense =
+                RecurringExpenseData(
+                    id = 1,
+                    name = "Netflix",
+                    description = "Streaming",
+                    price = CurrencyValue(9.99f, "USD"),
+                    monthlyPrice = CurrencyValue(9.99f, "USD"),
+                    everyXRecurrence = 1,
+                    recurrence = Recurrence.Monthly,
+                    tags = emptyList(),
+                    firstPayment = null,
+                    notifyForExpense = true,
+                    reminders = emptyList(), // No reminders in DB
+                )
+
+            expenseRepository.insert(existingExpense)
+
+            val viewModel =
+                EditRecurringExpenseViewModel(
+                    expenseId = 1,
+                    expenseRepository = expenseRepository,
+                    currencyProvider = currencyProvider,
+                    userPreferencesRepository = userPreferencesRepository,
+                )
+
+            advanceUntilIdle()
+
+            // Should show default reminder but no unsaved changes
+            assertEquals(1, viewModel.reminders.size)
+            assertEquals(3, viewModel.reminders[0].daysBeforePayment)
+
+            var dismissed = false
+            viewModel.onBackPressed { dismissed = true }
+
+            advanceUntilIdle()
+
+            // Should not show dialog since the default reminder matches expectations
+            assertTrue(dismissed)
+            assertFalse(viewModel.showDismissUnsavedChangesDialog)
+        }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,6 +42,7 @@ androidx-navigation-compose = { module = "org.jetbrains.androidx.navigation:navi
 androidx-test-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-junit" }
 compose-colorpicker = { module = "com.github.skydoves:colorpicker-compose", version.ref = "colorpicker" }
 koin-android = { module = "io.insert-koin:koin-android" }
+compose-ui-backhandler = { module = "org.jetbrains.compose.ui:ui-backhandler", version.ref = "compose-plugin" }
 koin-androidx-compose = { module = "io.insert-koin:koin-androidx-compose" }
 koin-bom = { module = "io.insert-koin:koin-bom", version.ref = "koin" }
 koin-compose = { module = "io.insert-koin:koin-compose" }


### PR DESCRIPTION
When creating a new expense or editing an existing one clicking back doesn't require any additional confirmation by the user. This way changes might be lost even though the user wanted to save them.

fixes: #746