### PR TITLE
Fix crash when using currency unkown to system

### DIFF
--- a/app/src/androidMain/kotlin/de/dbauer/expensetracker/Extensions.android.kt
+++ b/app/src/androidMain/kotlin/de/dbauer/expensetracker/Extensions.android.kt
@@ -18,7 +18,11 @@ import kotlin.time.Instant
 actual fun Float.toCurrencyString(currencyCode: String): String {
     val currencyInstance = NumberFormat.getCurrencyInstance()
     if (currencyCode.isNotEmpty()) {
-        currencyInstance.currency = Currency.getInstance(currencyCode)
+        try {
+            currencyInstance.currency = Currency.getInstance(currencyCode)
+        } catch (_: IllegalArgumentException) {
+            return "${String.format(Locale.getDefault(), "%.2f", this)} $currencyCode"
+        }
     }
     return currencyInstance.format(this)
 }

--- a/app/src/jvmMain/kotlin/de/dbauer/expensetracker/Extensions.desktop.kt
+++ b/app/src/jvmMain/kotlin/de/dbauer/expensetracker/Extensions.desktop.kt
@@ -15,7 +15,11 @@ import kotlin.time.Instant
 actual fun Float.toCurrencyString(currencyCode: String): String {
     val currencyInstance = NumberFormat.getCurrencyInstance()
     if (currencyCode.isNotEmpty()) {
-        currencyInstance.currency = Currency.getInstance(currencyCode)
+        try {
+            currencyInstance.currency = Currency.getInstance(currencyCode)
+        } catch (_: IllegalArgumentException) {
+            return "${String.format(Locale.getDefault(), "%.2f", this)} $currencyCode"
+        }
     }
     return currencyInstance.format(this)
 }


### PR DESCRIPTION
Fix a crash when using a currency (e.g. crypto) which isn't known to the system currency formatter. Introduce a fallback case to resolve it.

fixes: #767 