### PR TITLE
Create new release 0.19.4

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "de.dbauer.expensetracker"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 55
-        versionName = "0.19.3"
+        versionCode = 56
+        versionName = "0.19.4"
 
         buildFeatures {
             buildConfig = true

--- a/fastlane/metadata/android/en-US/changelogs/56.txt
+++ b/fastlane/metadata/android/en-US/changelogs/56.txt
@@ -1,0 +1,8 @@
+Changelog 0.19.4:
+* Fix: Properly mask ripple effect on expense cards
+* Fix unsafe Intent Lint warning
+* Chinese (Traditional Han script) translation updated
+* Update exchange rates
+* Update dependencies
+
+Full Changelog: https://github.com/DennisBauer/RecurringExpenseTracker/releases/tag/v0.19.4


### PR DESCRIPTION
* Fix: Properly mask ripple effect on expense cards
* Fix unsafe Intent Lint warning
* Chinese (Traditional Han script) translation updated
* Update exchange rates
* Update dependencies