### PR TITLE
Define minSdkVersion to prevent legacy permissions added to the manifest

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -16,6 +16,7 @@ kotlin {
     androidLibrary {
         namespace = "de.dbauer.expensetracker.shared"
         compileSdk = libs.versions.android.compileSdk.get().toInt()
+        minSdk = libs.versions.android.minSdk.get().toInt()
 
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_21)


### PR DESCRIPTION
Defining a minSdkVersion for the shared lib prevents some legacy permissions to be added to the AndroidManifest.xml: android.permission.READ_PHONE_STATE
android.permission.READ_EXTERNAL_STORAGE
android.permission.WRITE_EXTERNAL_STORAGE

fixes: #827