### PR TITLE
Create new release 0.19.5

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "de.dbauer.expensetracker"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 56
-        versionName = "0.19.4"
+        versionCode = 57
+        versionName = "0.19.5"
 
         buildFeatures {
             buildConfig = true

--- a/fastlane/metadata/android/en-US/changelogs/57.txt
+++ b/fastlane/metadata/android/en-US/changelogs/57.txt
@@ -1,0 +1,7 @@
+Changelog 0.19.5:
+* Fix: Define minSdkVersion to prevent legacy permissions added to the manifest
+In the last update some legacy permissions were added to the app by accident which got removed again in this update.
+* (Lithuanian) translation updated
+* Update dependencies
+
+Full Changelog: https://github.com/DennisBauer/RecurringExpenseTracker/releases/tag/v0.19.5


### PR DESCRIPTION
* Fix: Define minSdkVersion to prevent legacy permissions added to the manifest
   In the last update some legacy permissions were added to the app by
  accident which got removed again in this update.
* (Lithuanian) translation updated
* Update dependencies