### PR TITLE
Allow defining the horizon of upcoming payments in the settings

### DIFF
--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -82,6 +82,14 @@
     <string name="settings_theme_mode_light">Hell</string>
     <string name="settings_theme_mode_amoled">AMOLED</string>
     <string name="settings_default_tab">Standard Tab</string>
+    <string name="settings_upcoming_horizon">Anzeigezeitraum</string>
+    <string name="settings_upcoming_horizon_1_month">1 Monat</string>
+    <string name="settings_upcoming_horizon_3_months">3 Monate</string>
+    <string name="settings_upcoming_horizon_6_months">6 Monate</string>
+    <string name="settings_upcoming_horizon_1_year">1 Jahr</string>
+    <string name="settings_upcoming_horizon_2_years">2 Jahre</string>
+    <string name="settings_upcoming_horizon_5_years">5 Jahre</string>
+    <string name="settings_upcoming_horizon_10_years">10 Jahre</string>
     <string name="settings_currency">Währung</string>
     <string name="settings_default_currency">Standardwährung</string>
     <string name="settings_choose_currency">Währung auswählen</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -88,6 +88,14 @@
     <string name="settings_theme_mode_light">Light</string>
     <string name="settings_theme_mode_amoled">AMOLED</string>
     <string name="settings_default_tab">Default tab</string>
+    <string name="settings_upcoming_horizon">Upcoming horizon</string>
+    <string name="settings_upcoming_horizon_1_month">1 month</string>
+    <string name="settings_upcoming_horizon_3_months">3 months</string>
+    <string name="settings_upcoming_horizon_6_months">6 months</string>
+    <string name="settings_upcoming_horizon_1_year">1 year</string>
+    <string name="settings_upcoming_horizon_2_years">2 years</string>
+    <string name="settings_upcoming_horizon_5_years">5 years</string>
+    <string name="settings_upcoming_horizon_10_years">10 years</string>
     <string name="settings_currency">Currency</string>
     <string name="settings_default_currency">Default Currency</string>
     <string name="settings_choose_currency">Choose Currency</string>

--- a/shared/src/commonMain/kotlin/de/dbauer/expensetracker/shared/model/UpcomingPaymentsExpander.kt
+++ b/shared/src/commonMain/kotlin/de/dbauer/expensetracker/shared/model/UpcomingPaymentsExpander.kt
@@ -1,0 +1,202 @@
+package de.dbauer.expensetracker.shared.model
+
+import de.dbauer.expensetracker.shared.data.RecurringExpenseData
+import de.dbauer.expensetracker.shared.data.UpcomingPaymentData
+import de.dbauer.expensetracker.shared.model.database.IExpenseRepository
+import de.dbauer.expensetracker.shared.toLocaleString
+import kotlinx.datetime.DatePeriod
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.monthsUntil
+import kotlinx.datetime.plus
+
+object UpcomingPaymentsExpander {
+    fun expandAutoAdvance(
+        expense: RecurringExpenseData,
+        yearMonthIterator: LocalDate,
+        from: LocalDate,
+        payments: MutableList<UpcomingPaymentData>,
+    ) {
+        var nextPaymentDay = expense.getNextPaymentDayAfter(yearMonthIterator) ?: return
+        while (nextPaymentDay < from) {
+            nextPaymentDay =
+                expense.getNextPaymentDayAfter(nextPaymentDay.plus(1, DateTimeUnit.DAY))
+                    ?: return
+        }
+        while (nextPaymentDay.isSameMonth(yearMonthIterator)) {
+            val nextPaymentRemainingDays =
+                DateTimeCalculator.getDaysFromUntil(from = from, until = nextPaymentDay)
+            val nextPaymentDate = nextPaymentDay.atStartOfDayIn(TimeZone.UTC).toLocaleString()
+            val paymentDateEpoch = nextPaymentDay.atStartOfDayIn(TimeZone.UTC).toEpochMilliseconds()
+            payments.add(
+                UpcomingPaymentData(
+                    id = expense.id,
+                    name = expense.name,
+                    price = expense.price,
+                    nextPaymentRemainingDays = nextPaymentRemainingDays,
+                    nextPaymentDate = nextPaymentDate,
+                    tags = expense.tags,
+                    requiresConfirmation = false,
+                    isPaid = false,
+                    paymentDateEpoch = paymentDateEpoch,
+                ),
+            )
+            nextPaymentDay =
+                expense.getNextPaymentDayAfter(nextPaymentDay.plus(1, DateTimeUnit.DAY))
+                    ?: return
+        }
+    }
+
+    fun expandManualConfirmation(
+        expense: RecurringExpenseData,
+        yearMonthIterator: LocalDate,
+        from: LocalDate,
+        paidDates: Set<Long>,
+        unpaidPayments: MutableList<UpcomingPaymentData>,
+        paidPayments: MutableList<UpcomingPaymentData>,
+    ) {
+        var nextPaymentDay = expense.getNextPaymentDayAfter(yearMonthIterator) ?: return
+
+        while (nextPaymentDay.isSameMonth(yearMonthIterator)) {
+            val paymentDateEpoch = nextPaymentDay.atStartOfDayIn(TimeZone.UTC).toEpochMilliseconds()
+            val isPaid = paidDates.contains(paymentDateEpoch)
+            val nextPaymentRemainingDays =
+                DateTimeCalculator.getDaysFromUntil(from = from, until = nextPaymentDay)
+            val nextPaymentDate = nextPaymentDay.atStartOfDayIn(TimeZone.UTC).toLocaleString()
+
+            val paymentData =
+                UpcomingPaymentData(
+                    id = expense.id,
+                    name = expense.name,
+                    price = expense.price,
+                    nextPaymentRemainingDays = nextPaymentRemainingDays,
+                    nextPaymentDate = nextPaymentDate,
+                    tags = expense.tags,
+                    requiresConfirmation = true,
+                    isPaid = isPaid,
+                    paymentDateEpoch = paymentDateEpoch,
+                )
+
+            if (isPaid) {
+                paidPayments.add(paymentData)
+            } else {
+                if (nextPaymentRemainingDays >= 0 || yearMonthIterator.isSameMonth(from)) {
+                    unpaidPayments.add(paymentData)
+                }
+            }
+
+            nextPaymentDay =
+                expense.getNextPaymentDayAfter(nextPaymentDay.plus(1, DateTimeUnit.DAY))
+                    ?: return
+        }
+    }
+
+    fun expandPastMonth(
+        expense: RecurringExpenseData,
+        yearMonthIterator: LocalDate,
+        from: LocalDate,
+        paidDates: Set<Long>,
+        unpaidPayments: MutableList<UpcomingPaymentData>,
+        paidPayments: MutableList<UpcomingPaymentData>,
+    ) {
+        var nextPaymentDay = expense.getNextPaymentDayAfter(yearMonthIterator) ?: return
+
+        while (nextPaymentDay.isSameMonth(yearMonthIterator)) {
+            val paymentDateEpoch = nextPaymentDay.atStartOfDayIn(TimeZone.UTC).toEpochMilliseconds()
+            val isPaid =
+                if (expense.requireManualConfirmation) {
+                    paidDates.contains(paymentDateEpoch)
+                } else {
+                    false
+                }
+            val nextPaymentRemainingDays =
+                DateTimeCalculator.getDaysFromUntil(from = from, until = nextPaymentDay)
+            val nextPaymentDate = nextPaymentDay.atStartOfDayIn(TimeZone.UTC).toLocaleString()
+
+            val paymentData =
+                UpcomingPaymentData(
+                    id = expense.id,
+                    name = expense.name,
+                    price = expense.price,
+                    nextPaymentRemainingDays = nextPaymentRemainingDays,
+                    nextPaymentDate = nextPaymentDate,
+                    tags = expense.tags,
+                    requiresConfirmation = expense.requireManualConfirmation,
+                    isPaid = isPaid,
+                    paymentDateEpoch = paymentDateEpoch,
+                )
+
+            if (isPaid) {
+                paidPayments.add(paymentData)
+            } else {
+                unpaidPayments.add(paymentData)
+            }
+
+            nextPaymentDay =
+                expense.getNextPaymentDayAfter(nextPaymentDay.plus(1, DateTimeUnit.DAY))
+                    ?: return
+        }
+    }
+
+    /**
+     * Builds a flat, future-only list of upcoming payments using the same projection rules as the
+     * Upcoming screen (auto-advance + manual-confirmation with current-month overdue handling).
+     * No past months are included.
+     */
+    suspend fun collectFuturePayments(
+        expenseRepository: IExpenseRepository,
+        recurringExpenses: List<RecurringExpenseData>,
+        from: LocalDate,
+        until: LocalDate,
+    ): List<UpcomingPaymentData> {
+        val currentMonthStart = LocalDate(from.year, from.month, 1)
+        var yearMonthIterator = currentMonthStart
+        val yearMonthUntil = LocalDate(until.year, until.month, 1)
+        if (yearMonthIterator >= yearMonthUntil) return emptyList()
+
+        val paidByExpense = mutableMapOf<Int, Set<Long>>()
+        recurringExpenses.filter { it.requireManualConfirmation }.forEach { expense ->
+            paidByExpense[expense.id] = expenseRepository.getPaymentRecordsForExpense(expense.id).toSet()
+        }
+
+        val result = mutableListOf<UpcomingPaymentData>()
+        do {
+            val unpaidThisMonth = mutableListOf<UpcomingPaymentData>()
+            val paidThisMonth = mutableListOf<UpcomingPaymentData>()
+            recurringExpenses.forEach { expense ->
+                val paidDates = paidByExpense[expense.id] ?: emptySet()
+                if (expense.requireManualConfirmation) {
+                    expandManualConfirmation(
+                        expense = expense,
+                        yearMonthIterator = yearMonthIterator,
+                        from = from,
+                        paidDates = paidDates,
+                        unpaidPayments = unpaidThisMonth,
+                        paidPayments = paidThisMonth,
+                    )
+                } else {
+                    expandAutoAdvance(
+                        expense = expense,
+                        yearMonthIterator = yearMonthIterator,
+                        from = from,
+                        payments = unpaidThisMonth,
+                    )
+                }
+            }
+            unpaidThisMonth.sortBy { it.nextPaymentRemainingDays }
+            paidThisMonth.sortBy { it.nextPaymentRemainingDays }
+            result.addAll(unpaidThisMonth)
+            result.addAll(paidThisMonth)
+
+            yearMonthIterator = yearMonthIterator.plus(DatePeriod(months = 1))
+        } while (yearMonthIterator.monthsUntil(yearMonthUntil) > 0)
+
+        return result
+    }
+
+    private fun LocalDate.isSameMonth(other: LocalDate): Boolean {
+        return year == other.year && month == other.month
+    }
+}

--- a/shared/src/commonMain/kotlin/de/dbauer/expensetracker/shared/model/datastore/FakeUserPreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/de/dbauer/expensetracker/shared/model/datastore/FakeUserPreferencesRepository.kt
@@ -39,4 +39,6 @@ class FakeUserPreferencesRepository() : IUserPreferencesRepository {
         FakePreference(false)
     override val whatsNewVersionShown: IUserPreferencesRepository.IPreference<Int>
         get() = FakePreference(0)
+    override val upcomingPaymentHorizonMonths: IUserPreferencesRepository.IPreference<Int> =
+        FakePreference(120)
 }

--- a/shared/src/commonMain/kotlin/de/dbauer/expensetracker/shared/model/datastore/IUserPreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/de/dbauer/expensetracker/shared/model/datastore/IUserPreferencesRepository.kt
@@ -25,4 +25,5 @@ interface IUserPreferencesRepository {
     val upcomingPaymentNotificationDaysAdvance: IPreference<Int>
     val widgetBackgroundTransparent: IPreference<Boolean>
     val whatsNewVersionShown: IPreference<Int>
+    val upcomingPaymentHorizonMonths: IPreference<Int>
 }

--- a/shared/src/commonMain/kotlin/de/dbauer/expensetracker/shared/model/datastore/UserPreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/de/dbauer/expensetracker/shared/model/datastore/UserPreferencesRepository.kt
@@ -64,4 +64,7 @@ class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) :
         Preference(booleanPreferencesKey("WIDGET_BACKGROUND_TRANSPARENT"), false)
     override val whatsNewVersionShown: IUserPreferencesRepository.IPreference<Int> =
         Preference(intPreferencesKey("WHATS_NEW_VERSION_SHOWN"), 0)
+
+    override val upcomingPaymentHorizonMonths =
+        Preference(intPreferencesKey("UPCOMING_PAYMENT_HORIZON_MONTHS"), 120)
 }

--- a/shared/src/commonMain/kotlin/de/dbauer/expensetracker/shared/ui/UpcomingHorizon.kt
+++ b/shared/src/commonMain/kotlin/de/dbauer/expensetracker/shared/ui/UpcomingHorizon.kt
@@ -1,0 +1,16 @@
+package de.dbauer.expensetracker.shared.ui
+
+enum class UpcomingHorizon(val months: Int) {
+    OneMonth(1),
+    ThreeMonths(3),
+    SixMonths(6),
+    OneYear(12),
+    TwoYears(24),
+    FiveYears(60),
+    TenYears(120),
+    ;
+
+    companion object {
+        fun fromMonths(value: Int) = entries.firstOrNull { it.months == value } ?: TenYears
+    }
+}

--- a/shared/src/commonMain/kotlin/de/dbauer/expensetracker/shared/ui/settings/SettingsMainScreen.kt
+++ b/shared/src/commonMain/kotlin/de/dbauer/expensetracker/shared/ui/settings/SettingsMainScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.rounded.CurrencyExchange
 import androidx.compose.material.icons.rounded.DarkMode
 import androidx.compose.material.icons.rounded.DateRange
 import androidx.compose.material.icons.rounded.Fingerprint
+import androidx.compose.material.icons.rounded.HourglassEmpty
 import androidx.compose.material.icons.rounded.Info
 import androidx.compose.material.icons.rounded.Notifications
 import androidx.compose.material.icons.rounded.Restore
@@ -46,6 +47,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import de.dbauer.expensetracker.shared.ui.DefaultTab
 import de.dbauer.expensetracker.shared.ui.ThemeMode
+import de.dbauer.expensetracker.shared.ui.UpcomingHorizon
 import de.dbauer.expensetracker.shared.ui.elements.TimePickerDialog
 import de.dbauer.expensetracker.shared.viewmodel.SettingsViewModel
 import kotlinx.datetime.LocalTime
@@ -81,6 +83,14 @@ import recurringexpensetracker.shared.generated.resources.settings_theme_mode_da
 import recurringexpensetracker.shared.generated.resources.settings_theme_mode_follow_system
 import recurringexpensetracker.shared.generated.resources.settings_theme_mode_light
 import recurringexpensetracker.shared.generated.resources.settings_title_security
+import recurringexpensetracker.shared.generated.resources.settings_upcoming_horizon
+import recurringexpensetracker.shared.generated.resources.settings_upcoming_horizon_10_years
+import recurringexpensetracker.shared.generated.resources.settings_upcoming_horizon_1_month
+import recurringexpensetracker.shared.generated.resources.settings_upcoming_horizon_1_year
+import recurringexpensetracker.shared.generated.resources.settings_upcoming_horizon_2_years
+import recurringexpensetracker.shared.generated.resources.settings_upcoming_horizon_3_months
+import recurringexpensetracker.shared.generated.resources.settings_upcoming_horizon_5_years
+import recurringexpensetracker.shared.generated.resources.settings_upcoming_horizon_6_months
 import recurringexpensetracker.shared.generated.resources.tags_screen_title
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -133,6 +143,13 @@ fun SettingsMainScreen(
                 },
             onClick = viewModel::onClickDefaultTabSelection,
             icon = Icons.Rounded.Rocket,
+        )
+        val upcomingHorizon by viewModel.selectedUpcomingHorizon.collectAsState(UpcomingHorizon.TenYears)
+        SettingsClickableElement(
+            title = stringResource(Res.string.settings_upcoming_horizon),
+            subtitle = stringResource(upcomingHorizon.labelRes()),
+            onClick = viewModel::onClickUpcomingHorizonSelection,
+            icon = Icons.Rounded.HourglassEmpty,
         )
         SettingsClickableElement(
             title = stringResource(Res.string.tags_screen_title),
@@ -314,6 +331,28 @@ fun SettingsMainScreen(
             },
             confirmButton = {},
         )
+    } else if (viewModel.showUpcomingHorizonSelectionDialog) {
+        val current by viewModel.selectedUpcomingHorizon.collectAsState(UpcomingHorizon.TenYears)
+        AlertDialog(
+            onDismissRequest = viewModel::onDismissUpcomingHorizonSelectionDialog,
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(
+                        text = stringResource(Res.string.settings_upcoming_horizon),
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier.padding(bottom = 8.dp),
+                    )
+                    UpcomingHorizon.entries.forEach { horizon ->
+                        DialogCheckbox(
+                            text = stringResource(horizon.labelRes()),
+                            checked = current == horizon,
+                            onClick = { viewModel.onSelectUpcomingHorizon(horizon) },
+                        )
+                    }
+                }
+            },
+            confirmButton = {},
+        )
     } else if (viewModel.upcomingPaymentNotificationTimePickerDialog) {
         val timePickerState =
             rememberTimePickerState(
@@ -380,6 +419,17 @@ fun SettingsMainScreen(
         )
     }
 }
+
+private fun UpcomingHorizon.labelRes() =
+    when (this) {
+        UpcomingHorizon.OneMonth -> Res.string.settings_upcoming_horizon_1_month
+        UpcomingHorizon.ThreeMonths -> Res.string.settings_upcoming_horizon_3_months
+        UpcomingHorizon.SixMonths -> Res.string.settings_upcoming_horizon_6_months
+        UpcomingHorizon.OneYear -> Res.string.settings_upcoming_horizon_1_year
+        UpcomingHorizon.TwoYears -> Res.string.settings_upcoming_horizon_2_years
+        UpcomingHorizon.FiveYears -> Res.string.settings_upcoming_horizon_5_years
+        UpcomingHorizon.TenYears -> Res.string.settings_upcoming_horizon_10_years
+    }
 
 @Composable
 fun DialogCheckbox(

--- a/shared/src/commonMain/kotlin/de/dbauer/expensetracker/shared/viewmodel/SettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/de/dbauer/expensetracker/shared/viewmodel/SettingsViewModel.kt
@@ -14,6 +14,7 @@ import de.dbauer.expensetracker.shared.model.IExchangeRateProvider
 import de.dbauer.expensetracker.shared.model.datastore.IUserPreferencesRepository
 import de.dbauer.expensetracker.shared.ui.DefaultTab
 import de.dbauer.expensetracker.shared.ui.ThemeMode
+import de.dbauer.expensetracker.shared.ui.UpcomingHorizon
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
@@ -46,6 +47,11 @@ class SettingsViewModel(
         private set
     var upcomingPaymentNotificationDaysAdvance = userPreferencesRepository.upcomingPaymentNotificationDaysAdvance
     var upcomingPaymentNotificationDaysAdvanceDialog by mutableStateOf(false)
+        private set
+    var showUpcomingHorizonSelectionDialog by mutableStateOf(false)
+        private set
+    var selectedUpcomingHorizon =
+        userPreferencesRepository.upcomingPaymentHorizonMonths.get().map { UpcomingHorizon.fromMonths(it) }
         private set
 
     var currencySearchQuery by mutableStateOf("")
@@ -161,6 +167,21 @@ class SettingsViewModel(
             userPreferencesRepository.upcomingPaymentNotificationDaysAdvance.save(days)
         }
         upcomingPaymentNotificationDaysAdvanceDialog = false
+    }
+
+    fun onClickUpcomingHorizonSelection() {
+        showUpcomingHorizonSelectionDialog = true
+    }
+
+    fun onDismissUpcomingHorizonSelectionDialog() {
+        showUpcomingHorizonSelectionDialog = false
+    }
+
+    fun onSelectUpcomingHorizon(horizon: UpcomingHorizon) {
+        viewModelScope.launch {
+            userPreferencesRepository.upcomingPaymentHorizonMonths.save(horizon.months)
+            onDismissUpcomingHorizonSelectionDialog()
+        }
     }
 
     fun onCurrencySearchQueryChange(query: String) {

--- a/shared/src/commonMain/kotlin/de/dbauer/expensetracker/shared/viewmodel/UpcomingPaymentsViewModel.kt
+++ b/shared/src/commonMain/kotlin/de/dbauer/expensetracker/shared/viewmodel/UpcomingPaymentsViewModel.kt
@@ -7,24 +7,22 @@ import de.dbauer.expensetracker.shared.data.CurrencyValue
 import de.dbauer.expensetracker.shared.data.RecurringExpenseData
 import de.dbauer.expensetracker.shared.data.UpcomingPaymentData
 import de.dbauer.expensetracker.shared.getDefaultCurrencyCode
-import de.dbauer.expensetracker.shared.model.DateTimeCalculator
 import de.dbauer.expensetracker.shared.model.IExchangeRateProvider
+import de.dbauer.expensetracker.shared.model.UpcomingPaymentsExpander
 import de.dbauer.expensetracker.shared.model.database.IExpenseRepository
 import de.dbauer.expensetracker.shared.model.datastore.IUserPreferencesRepository
 import de.dbauer.expensetracker.shared.model.getSystemCurrencyCode
 import de.dbauer.expensetracker.shared.toCurrencyString
-import de.dbauer.expensetracker.shared.toLocaleString
 import de.dbauer.expensetracker.shared.toMonthYearStringUTC
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.DatePeriod
-import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
-import kotlinx.datetime.atStartOfDayIn
 import kotlinx.datetime.minus
 import kotlinx.datetime.monthsUntil
 import kotlinx.datetime.plus
@@ -72,12 +70,17 @@ class UpcomingPaymentsViewModel(
         private set
 
     private val defaultCurrency = userPreferencesRepository.defaultCurrency.get()
+    private val horizonMonthsFlow = userPreferencesRepository.upcomingPaymentHorizonMonths.get()
 
     init {
         viewModelScope.launch {
-            expenseRepository.allRecurringExpensesByPrice.collect { recurringExpenses ->
-                onDatabaseUpdated(recurringExpenses)
-            }
+            combine(
+                expenseRepository.allRecurringExpensesByPrice,
+                horizonMonthsFlow,
+            ) { expenses, horizonMonths -> expenses to horizonMonths }
+                .collect { (recurringExpenses, horizonMonths) ->
+                    onDatabaseUpdated(recurringExpenses, horizonMonths)
+                }
         }
     }
 
@@ -114,10 +117,14 @@ class UpcomingPaymentsViewModel(
 
     private suspend fun refreshData() {
         val recurringExpenses = expenseRepository.allRecurringExpensesByPrice.first()
-        onDatabaseUpdated(recurringExpenses)
+        val horizonMonths = horizonMonthsFlow.first()
+        onDatabaseUpdated(recurringExpenses, horizonMonths)
     }
 
-    private suspend fun onDatabaseUpdated(recurringExpenses: List<RecurringExpenseData>) {
+    private suspend fun onDatabaseUpdated(
+        recurringExpenses: List<RecurringExpenseData>,
+        horizonMonths: Int,
+    ) {
         val from =
             Clock.System
                 .now()
@@ -127,7 +134,7 @@ class UpcomingPaymentsViewModel(
             createUpcomingPaymentData(
                 recurringExpenses = recurringExpenses,
                 from = from,
-                until = from.plus(DatePeriod(years = 10)),
+                until = from.plus(DatePeriod(months = horizonMonths)),
                 pastMonths = PAST_MONTHS_COUNT,
             )
         upcomingStartIndex =
@@ -197,7 +204,7 @@ class UpcomingPaymentsViewModel(
                     val paidDates = paymentRecordsByExpenseId[expense.id] ?: emptySet()
 
                     if (isPastMonth) {
-                        processPastMonthExpense(
+                        UpcomingPaymentsExpander.expandPastMonth(
                             expense = expense,
                             yearMonthIterator = yearMonthIterator,
                             from = from,
@@ -206,7 +213,7 @@ class UpcomingPaymentsViewModel(
                             paidPayments = paidPaymentsThisMonth,
                         )
                     } else if (expense.requireManualConfirmation) {
-                        processManualConfirmationExpense(
+                        UpcomingPaymentsExpander.expandManualConfirmation(
                             expense = expense,
                             yearMonthIterator = yearMonthIterator,
                             from = from,
@@ -215,7 +222,7 @@ class UpcomingPaymentsViewModel(
                             paidPayments = paidPaymentsThisMonth,
                         )
                     } else {
-                        processAutoAdvanceExpense(
+                        UpcomingPaymentsExpander.expandAutoAdvance(
                             expense = expense,
                             yearMonthIterator = yearMonthIterator,
                             from = from,
@@ -358,149 +365,12 @@ class UpcomingPaymentsViewModel(
         return currencyPrefix + sum.toCurrencyString(defaultCurrency.first())
     }
 
-    private fun processAutoAdvanceExpense(
-        expense: RecurringExpenseData,
-        yearMonthIterator: LocalDate,
-        from: LocalDate,
-        payments: MutableList<UpcomingPaymentData>,
-    ) {
-        var nextPaymentDay = expense.getNextPaymentDayAfter(yearMonthIterator) ?: return
-        while (nextPaymentDay < from) {
-            nextPaymentDay =
-                expense.getNextPaymentDayAfter(nextPaymentDay.plus(1, DateTimeUnit.DAY))
-                    ?: return
-        }
-        while (nextPaymentDay.isSameMonth(yearMonthIterator)) {
-            val nextPaymentRemainingDays =
-                DateTimeCalculator.getDaysFromUntil(from = from, until = nextPaymentDay)
-            val nextPaymentDate = nextPaymentDay.atStartOfDayIn(TimeZone.UTC).toLocaleString()
-            val paymentDateEpoch = nextPaymentDay.atStartOfDayIn(TimeZone.UTC).toEpochMilliseconds()
-            payments.add(
-                UpcomingPaymentData(
-                    id = expense.id,
-                    name = expense.name,
-                    price = expense.price,
-                    nextPaymentRemainingDays = nextPaymentRemainingDays,
-                    nextPaymentDate = nextPaymentDate,
-                    tags = expense.tags,
-                    requiresConfirmation = false,
-                    isPaid = false,
-                    paymentDateEpoch = paymentDateEpoch,
-                ),
-            )
-            nextPaymentDay =
-                expense.getNextPaymentDayAfter(nextPaymentDay.plus(1, DateTimeUnit.DAY))
-                    ?: return
-        }
-    }
-
-    private fun processManualConfirmationExpense(
-        expense: RecurringExpenseData,
-        yearMonthIterator: LocalDate,
-        from: LocalDate,
-        paidDates: Set<Long>,
-        unpaidPayments: MutableList<UpcomingPaymentData>,
-        paidPayments: MutableList<UpcomingPaymentData>,
-    ) {
-        // For manual confirmation expenses, we need to find all occurrences in this month,
-        // including past ones that haven't been paid yet (overdue).
-        // Start from the first of the month (or earlier for overdue items in the current month)
-        val monthStart = yearMonthIterator
-
-        var nextPaymentDay = expense.getNextPaymentDayAfter(monthStart) ?: return
-
-        while (nextPaymentDay.isSameMonth(yearMonthIterator)) {
-            val paymentDateEpoch = nextPaymentDay.atStartOfDayIn(TimeZone.UTC).toEpochMilliseconds()
-            val isPaid = paidDates.contains(paymentDateEpoch)
-            val nextPaymentRemainingDays =
-                DateTimeCalculator.getDaysFromUntil(from = from, until = nextPaymentDay)
-            val nextPaymentDate = nextPaymentDay.atStartOfDayIn(TimeZone.UTC).toLocaleString()
-
-            val paymentData =
-                UpcomingPaymentData(
-                    id = expense.id,
-                    name = expense.name,
-                    price = expense.price,
-                    nextPaymentRemainingDays = nextPaymentRemainingDays,
-                    nextPaymentDate = nextPaymentDate,
-                    tags = expense.tags,
-                    requiresConfirmation = true,
-                    isPaid = isPaid,
-                    paymentDateEpoch = paymentDateEpoch,
-                )
-
-            if (isPaid) {
-                paidPayments.add(paymentData)
-            } else {
-                // Only show future unpaid items, or overdue (past) unpaid items in the current month
-                if (nextPaymentRemainingDays >= 0 || yearMonthIterator.isSameMonth(from)) {
-                    unpaidPayments.add(paymentData)
-                }
-            }
-
-            nextPaymentDay =
-                expense.getNextPaymentDayAfter(nextPaymentDay.plus(1, DateTimeUnit.DAY))
-                    ?: return
-        }
-    }
-
     private suspend fun CurrencyValue.exchangeToDefaultCurrency(): CurrencyValue? {
         return exchangeRateProvider.exchangeCurrencyValue(this, getDefaultCurrencyCode())
     }
 
     private suspend fun getDefaultCurrencyCode(): String {
         return defaultCurrency.first().ifBlank { getSystemCurrencyCode() }
-    }
-
-    private fun LocalDate.isSameMonth(other: LocalDate): Boolean {
-        return year == other.year && month == other.month
-    }
-
-    private fun processPastMonthExpense(
-        expense: RecurringExpenseData,
-        yearMonthIterator: LocalDate,
-        from: LocalDate,
-        paidDates: Set<Long>,
-        unpaidPayments: MutableList<UpcomingPaymentData>,
-        paidPayments: MutableList<UpcomingPaymentData>,
-    ) {
-        var nextPaymentDay = expense.getNextPaymentDayAfter(yearMonthIterator) ?: return
-
-        while (nextPaymentDay.isSameMonth(yearMonthIterator)) {
-            val paymentDateEpoch = nextPaymentDay.atStartOfDayIn(TimeZone.UTC).toEpochMilliseconds()
-            val isPaid =
-                if (expense.requireManualConfirmation) {
-                    paidDates.contains(paymentDateEpoch)
-                } else {
-                    false
-                }
-            val nextPaymentRemainingDays =
-                DateTimeCalculator.getDaysFromUntil(from = from, until = nextPaymentDay)
-            val nextPaymentDate = nextPaymentDay.atStartOfDayIn(TimeZone.UTC).toLocaleString()
-
-            val paymentData =
-                UpcomingPaymentData(
-                    id = expense.id,
-                    name = expense.name,
-                    price = expense.price,
-                    nextPaymentRemainingDays = nextPaymentRemainingDays,
-                    nextPaymentDate = nextPaymentDate,
-                    tags = expense.tags,
-                    requiresConfirmation = expense.requireManualConfirmation,
-                    isPaid = isPaid,
-                    paymentDateEpoch = paymentDateEpoch,
-                )
-
-            if (isPaid) {
-                paidPayments.add(paymentData)
-            } else {
-                unpaidPayments.add(paymentData)
-            }
-
-            nextPaymentDay =
-                expense.getNextPaymentDayAfter(nextPaymentDay.plus(1, DateTimeUnit.DAY))
-                    ?: return
-        }
     }
 
     companion object {

--- a/shared/src/commonTest/kotlin/de/dbauer/expensetracker/shared/viewmodel/UpcomingPaymentsViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/de/dbauer/expensetracker/shared/viewmodel/UpcomingPaymentsViewModelTest.kt
@@ -943,6 +943,37 @@ class UpcomingPaymentsViewModelTest {
             assertTrue(paymentItems.all { !it.payment.isPaid })
         }
 
+    @Test
+    fun `horizon clamps upcoming list to configured window`() =
+        runTest {
+            val from = LocalDate(2025, 1, 1)
+            // 3-month horizon: April 1 onward must be excluded
+            val until = LocalDate(2025, 4, 1)
+            val inHorizon =
+                getTestExpense(
+                    name = "InHorizon",
+                    price = 5f,
+                    currencyCode = defaultCurrencyCode,
+                    recurrence = RecurrenceDatabase.Monthly,
+                    everyXRecurrence = 1,
+                    firstPayment = LocalDateTime(2025, 2, 10, 0, 0).toInstant(TimeZone.UTC),
+                )
+            val outOfHorizon =
+                getTestExpense(
+                    name = "OutOfHorizon",
+                    price = 5f,
+                    currencyCode = defaultCurrencyCode,
+                    recurrence = RecurrenceDatabase.Yearly,
+                    everyXRecurrence = 1,
+                    firstPayment = LocalDateTime(2025, 7, 10, 0, 0).toInstant(TimeZone.UTC),
+                )
+
+            val result = viewModel.createUpcomingPaymentData(listOf(inHorizon, outOfHorizon), from, until)
+            val names = result.filterIsInstance<UpcomingPayment.PaymentItem>().map { it.payment.name }
+            assertTrue(names.contains("InHorizon"))
+            assertTrue(!names.contains("OutOfHorizon"))
+        }
+
     private fun getTestExpense(
         name: String,
         price: Float,


### PR DESCRIPTION
Replaces the hard-coded 10-year projection in UpcomingPaymentsViewModel with the user-selected horizon. The Settings screen shows an "Upcoming horizon" picker (1/3/6/12 months, 2/5/10 years).

Also extracts the per-expense expansion helpers (auto-advance, manual confirmation, past-month) into a shared UpcomingPaymentsExpander object so the widget can reuse the exact same projection logic.

Fixes: #903