### PR TITLE
Create new release 0.21.1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "de.dbauer.expensetracker"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 64
-        versionName = "0.21.0"
+        versionCode = 65
+        versionName = "0.21.1"
 
         buildFeatures {
             buildConfig = true

--- a/fastlane/metadata/android/en-US/changelogs/65.txt
+++ b/fastlane/metadata/android/en-US/changelogs/65.txt
@@ -1,0 +1,6 @@
+Changelog 0.21.1:
+* Fix: Upcoming expenses show up further into the future than the end date
+* Translations updated
+* Update exchange rates and licenses
+
+Full Changelog: https://github.com/DennisBauer/RecurringExpenseTracker/releases/tag/v0.21.1


### PR DESCRIPTION
* Fix: Upcoming expenses show up further into the future than the end date
* Translations updated