### PR TITLE
Migrate from Room 2 to Room 3

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -22,6 +22,8 @@
 
 -dontwarn kotlinx.serialization.internal.AbstractPolymorphicSerializer
 
+-keep class * extends androidx.room3.RoomDatabase { <init>(); }
+# WorkManager (pulled in transitively via Glance) still uses Room 2 internally
 -keep class * extends androidx.room.RoomDatabase { <init>(); }
 
 # Ensure all Previews have been stripped https://issuetracker.google.com/issues/157891235#comment6

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,8 +28,8 @@ ktlint = "0.6.2"
 ktlint-plugin = "14.2.0"
 ktlint-version = "1.8.0"
 navigationevent-compose = "1.1.0"
-room = "2.8.4"
-sqlite = "2.6.2"
+room = "3.0.0"
+sqlite = "2.7.0"
 
 [libraries]
 aboutlibraries-compose-m3 = { module = "com.mikepenz:aboutlibraries-compose-m3", version.ref = "aboutLibraries" }
@@ -69,10 +69,10 @@ kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 ktlint = { module = "io.nlopez.compose.rules:ktlint", version.ref = "ktlint" }
 ktlint-version = { group = "com.pinterest.ktlint", name = "ktlint-ruleset-standard", version.ref = "ktlint-version" }
 navigationevent-compose = { module = "org.jetbrains.androidx.navigationevent:navigationevent-compose", version.ref = "navigationevent-compose" }
-room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
-room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
-room-runtime-android = { module = "androidx.room:room-runtime-android", version.ref = "room" }
+room-compiler = { module = "androidx.room3:room3-compiler", version.ref = "room" }
+room-runtime = { module = "androidx.room3:room3-runtime", version.ref = "room" }
 sqlite-bundled = { module = "androidx.sqlite:sqlite-bundled", version.ref = "sqlite" }
+sqlite-framework = { module = "androidx.sqlite:sqlite-framework", version.ref = "sqlite" }
 
 [plugins]
 aboutLibraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "aboutLibraries" }
@@ -84,4 +84,4 @@ kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref =
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 org-jlleitschuh-gradle-ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint-plugin" }
-room = { id = "androidx.room", version.ref = "room" }
+room = { id = "androidx.room3", version.ref = "room" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -56,6 +56,7 @@ kotlin {
         androidMain.dependencies {
             implementation(libs.koin.android)
             implementation(libs.koin.androidx.compose)
+            implementation(libs.sqlite.framework)
         }
         commonMain.dependencies {
             implementation(libs.androidx.datastore.preferences)
@@ -117,7 +118,7 @@ compose {
     }
 }
 
-room {
+room3 {
     schemaDirectory("$projectDir/schemas")
 }
 

--- a/shared/src/androidMain/kotlin/de/dbauer/expensetracker/shared/di/Module.android.kt
+++ b/shared/src/androidMain/kotlin/de/dbauer/expensetracker/shared/di/Module.android.kt
@@ -6,7 +6,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStoreFile
-import androidx.room.RoomDatabase
+import androidx.room3.RoomDatabase
 import de.dbauer.expensetracker.shared.model.database.RecurringExpenseDatabase
 import de.dbauer.expensetracker.shared.model.database.getDatabaseBuilder
 import de.dbauer.expensetracker.shared.model.datastore.IUserPreferencesRepository

--- a/shared/src/androidMain/kotlin/de/dbauer/expensetracker/shared/model/database/GetDatabaseBuilder.kt
+++ b/shared/src/androidMain/kotlin/de/dbauer/expensetracker/shared/model/database/GetDatabaseBuilder.kt
@@ -2,13 +2,15 @@ package de.dbauer.expensetracker.shared.model.database
 
 import Constants
 import android.content.Context
-import androidx.room.Room
-import androidx.room.RoomDatabase
+import androidx.room3.Room
+import androidx.room3.RoomDatabase
+import androidx.sqlite.driver.AndroidSQLiteDriver
 
 fun getDatabaseBuilder(context: Context): RoomDatabase.Builder<RecurringExpenseDatabase> {
     val dbFile = context.getDatabasePath(Constants.DATABASE_NAME)
-    return Room.databaseBuilder<RecurringExpenseDatabase>(
-        context = context.applicationContext,
-        name = dbFile.absolutePath,
-    )
+    return Room
+        .databaseBuilder<RecurringExpenseDatabase>(
+            context = context.applicationContext,
+            name = dbFile.absolutePath,
+        ).setDriver(AndroidSQLiteDriver())
 }

--- a/shared/src/commonMain/kotlin/de/dbauer/expensetracker/shared/model/database/ExpenseTagCrossRefEntry.kt
+++ b/shared/src/commonMain/kotlin/de/dbauer/expensetracker/shared/model/database/ExpenseTagCrossRefEntry.kt
@@ -1,7 +1,7 @@
 package de.dbauer.expensetracker.shared.model.database
 
-import androidx.room.Entity
-import androidx.room.Index
+import androidx.room3.Entity
+import androidx.room3.Index
 
 @Entity(
     tableName = "ExpenseTagCrossRef",

--- a/shared/src/commonMain/kotlin/de/dbauer/expensetracker/shared/model/database/PaymentRecordEntry.kt
+++ b/shared/src/commonMain/kotlin/de/dbauer/expensetracker/shared/model/database/PaymentRecordEntry.kt
@@ -1,10 +1,10 @@
 package de.dbauer.expensetracker.shared.model.database
 
-import androidx.room.ColumnInfo
-import androidx.room.Entity
-import androidx.room.ForeignKey
-import androidx.room.Index
-import androidx.room.PrimaryKey
+import androidx.room3.ColumnInfo
+import androidx.room3.Entity
+import androidx.room3.ForeignKey
+import androidx.room3.Index
+import androidx.room3.PrimaryKey
 
 @Entity(
     tableName = "payment_records",

--- a/shared/src/commonMain/kotlin/de/dbauer/expensetracker/shared/model/database/RecurringExpenseDao.kt
+++ b/shared/src/commonMain/kotlin/de/dbauer/expensetracker/shared/model/database/RecurringExpenseDao.kt
@@ -1,12 +1,12 @@
 package de.dbauer.expensetracker.shared.model.database
 
-import androidx.room.Dao
-import androidx.room.Delete
-import androidx.room.Insert
-import androidx.room.Query
-import androidx.room.Transaction
-import androidx.room.Update
-import androidx.room.Upsert
+import androidx.room3.Dao
+import androidx.room3.Delete
+import androidx.room3.Insert
+import androidx.room3.Query
+import androidx.room3.Transaction
+import androidx.room3.Update
+import androidx.room3.Upsert
 import kotlinx.coroutines.flow.Flow
 
 @Dao

--- a/shared/src/commonMain/kotlin/de/dbauer/expensetracker/shared/model/database/RecurringExpenseDatabase.kt
+++ b/shared/src/commonMain/kotlin/de/dbauer/expensetracker/shared/model/database/RecurringExpenseDatabase.kt
@@ -1,10 +1,10 @@
 package de.dbauer.expensetracker.shared.model.database
 
-import androidx.room.ConstructedBy
-import androidx.room.Database
-import androidx.room.RoomDatabase
-import androidx.room.RoomDatabaseConstructor
-import androidx.room.migration.Migration
+import androidx.room3.ConstructedBy
+import androidx.room3.Database
+import androidx.room3.RoomDatabase
+import androidx.room3.RoomDatabaseConstructor
+import androidx.room3.migration.Migration
 import androidx.sqlite.SQLiteConnection
 import androidx.sqlite.execSQL
 import kotlinx.coroutines.Dispatchers
@@ -50,7 +50,7 @@ abstract class RecurringExpenseDatabase : RoomDatabase() {
 
         private val migration_1_2 =
             object : Migration(1, 2) {
-                override fun migrate(connection: SQLiteConnection) {
+                override suspend fun migrate(connection: SQLiteConnection) {
                     connection.execSQL(
                         "ALTER TABLE recurring_expenses ADD COLUMN everyXRecurrence INTEGER DEFAULT 1",
                     )
@@ -60,28 +60,28 @@ abstract class RecurringExpenseDatabase : RoomDatabase() {
 
         private val migration_2_3 =
             object : Migration(2, 3) {
-                override fun migrate(connection: SQLiteConnection) {
+                override suspend fun migrate(connection: SQLiteConnection) {
                     connection.execSQL("ALTER TABLE recurring_expenses ADD COLUMN firstPayment INTEGER DEFAULT 0")
                 }
             }
 
         private val migration_3_4 =
             object : Migration(3, 4) {
-                override fun migrate(connection: SQLiteConnection) {
+                override suspend fun migrate(connection: SQLiteConnection) {
                     connection.execSQL("ALTER TABLE recurring_expenses ADD COLUMN color INTEGER DEFAULT 0")
                 }
             }
 
         private val migration_4_5 =
             object : Migration(4, 5) {
-                override fun migrate(connection: SQLiteConnection) {
+                override suspend fun migrate(connection: SQLiteConnection) {
                     connection.execSQL("UPDATE recurring_expenses SET firstPayment = NULL WHERE firstPayment = 0")
                 }
             }
 
         private val migration_5_6 =
             object : Migration(5, 6) {
-                override fun migrate(connection: SQLiteConnection) {
+                override suspend fun migrate(connection: SQLiteConnection) {
                     connection.execSQL(
                         "ALTER TABLE recurring_expenses ADD COLUMN currencyCode TEXT DEFAULT '' NOT NULL",
                     )
@@ -90,7 +90,7 @@ abstract class RecurringExpenseDatabase : RoomDatabase() {
 
         private val migration_6_7 =
             object : Migration(6, 7) {
-                override fun migrate(connection: SQLiteConnection) {
+                override suspend fun migrate(connection: SQLiteConnection) {
                     connection.execSQL(
                         "ALTER TABLE recurring_expenses ADD COLUMN notifyForExpense INTEGER NOT NULL DEFAULT 1",
                     )
@@ -104,7 +104,7 @@ abstract class RecurringExpenseDatabase : RoomDatabase() {
             }
         val migration_7_8 =
             object : Migration(7, 8) {
-                override fun migrate(connection: SQLiteConnection) {
+                override suspend fun migrate(connection: SQLiteConnection) {
                     // 1) Create new tables required by v8
                     connection.execSQL(
                         """
@@ -246,7 +246,7 @@ abstract class RecurringExpenseDatabase : RoomDatabase() {
             }
         val migration_8_9 =
             object : Migration(8, 9) {
-                override fun migrate(connection: SQLiteConnection) {
+                override suspend fun migrate(connection: SQLiteConnection) {
                     // 1) Create reminders table
                     connection.execSQL(
                         """
@@ -310,7 +310,7 @@ abstract class RecurringExpenseDatabase : RoomDatabase() {
             }
         val migration_9_10 =
             object : Migration(9, 10) {
-                override fun migrate(connection: SQLiteConnection) {
+                override suspend fun migrate(connection: SQLiteConnection) {
                     connection.execSQL(
                         "ALTER TABLE recurring_expenses ADD COLUMN requireManualConfirmation INTEGER NOT NULL DEFAULT 0",
                     )
@@ -331,7 +331,7 @@ abstract class RecurringExpenseDatabase : RoomDatabase() {
             }
         val migration_10_11 =
             object : Migration(10, 11) {
-                override fun migrate(connection: SQLiteConnection) {
+                override suspend fun migrate(connection: SQLiteConnection) {
                     connection.execSQL(
                         "ALTER TABLE recurring_expenses ADD COLUMN endDate INTEGER DEFAULT NULL",
                     )

--- a/shared/src/commonMain/kotlin/de/dbauer/expensetracker/shared/model/database/RecurringExpenseEntry.kt
+++ b/shared/src/commonMain/kotlin/de/dbauer/expensetracker/shared/model/database/RecurringExpenseEntry.kt
@@ -1,8 +1,8 @@
 package de.dbauer.expensetracker.shared.model.database
 
-import androidx.room.ColumnInfo
-import androidx.room.Entity
-import androidx.room.PrimaryKey
+import androidx.room3.ColumnInfo
+import androidx.room3.Entity
+import androidx.room3.PrimaryKey
 
 @Entity(tableName = "recurring_expenses")
 data class RecurringExpenseEntry(

--- a/shared/src/commonMain/kotlin/de/dbauer/expensetracker/shared/model/database/RecurringExpenseWithRemindersEntry.kt
+++ b/shared/src/commonMain/kotlin/de/dbauer/expensetracker/shared/model/database/RecurringExpenseWithRemindersEntry.kt
@@ -1,13 +1,13 @@
 package de.dbauer.expensetracker.shared.model.database
 
-import androidx.room.Embedded
-import androidx.room.Relation
+import androidx.room3.Embedded
+import androidx.room3.Relation
 
 data class RecurringExpenseWithRemindersEntry(
     @Embedded val expense: RecurringExpenseEntry,
     @Relation(
-        parentColumn = "id",
-        entityColumn = "expenseId",
+        parentColumns = ["id"],
+        entityColumns = ["expenseId"],
     )
     val reminders: List<ReminderEntry>,
 )

--- a/shared/src/commonMain/kotlin/de/dbauer/expensetracker/shared/model/database/RecurringExpenseWithTagsEntry.kt
+++ b/shared/src/commonMain/kotlin/de/dbauer/expensetracker/shared/model/database/RecurringExpenseWithTagsEntry.kt
@@ -1,25 +1,25 @@
 package de.dbauer.expensetracker.shared.model.database
 
-import androidx.room.Embedded
-import androidx.room.Junction
-import androidx.room.Relation
+import androidx.room3.Embedded
+import androidx.room3.Junction
+import androidx.room3.Relation
 
 data class RecurringExpenseWithTagsEntry(
     @Embedded val expense: RecurringExpenseEntry,
     @Relation(
-        parentColumn = "id",
-        entityColumn = "id",
+        parentColumns = ["id"],
+        entityColumns = ["id"],
         associateBy =
             Junction(
                 value = ExpenseTagCrossRefEntry::class,
-                parentColumn = "expenseId",
-                entityColumn = "tagId",
+                parentColumns = ["expenseId"],
+                entityColumns = ["tagId"],
             ),
     )
     val tags: List<TagEntry>,
     @Relation(
-        parentColumn = "id",
-        entityColumn = "expenseId",
+        parentColumns = ["id"],
+        entityColumns = ["expenseId"],
     )
     val reminders: List<ReminderEntry> = emptyList(),
 )

--- a/shared/src/commonMain/kotlin/de/dbauer/expensetracker/shared/model/database/ReminderEntry.kt
+++ b/shared/src/commonMain/kotlin/de/dbauer/expensetracker/shared/model/database/ReminderEntry.kt
@@ -1,10 +1,10 @@
 package de.dbauer.expensetracker.shared.model.database
 
-import androidx.room.ColumnInfo
-import androidx.room.Entity
-import androidx.room.ForeignKey
-import androidx.room.Index
-import androidx.room.PrimaryKey
+import androidx.room3.ColumnInfo
+import androidx.room3.Entity
+import androidx.room3.ForeignKey
+import androidx.room3.Index
+import androidx.room3.PrimaryKey
 
 @Entity(
     tableName = "reminders",

--- a/shared/src/commonMain/kotlin/de/dbauer/expensetracker/shared/model/database/TagEntry.kt
+++ b/shared/src/commonMain/kotlin/de/dbauer/expensetracker/shared/model/database/TagEntry.kt
@@ -1,8 +1,8 @@
 package de.dbauer.expensetracker.shared.model.database
 
-import androidx.room.ColumnInfo
-import androidx.room.Entity
-import androidx.room.PrimaryKey
+import androidx.room3.ColumnInfo
+import androidx.room3.Entity
+import androidx.room3.PrimaryKey
 
 @Entity(tableName = "tags")
 data class TagEntry(

--- a/shared/src/iosMain/kotlin/de/dbauer/expensetracker/shared/di/Module.ios.kt
+++ b/shared/src/iosMain/kotlin/de/dbauer/expensetracker/shared/di/Module.ios.kt
@@ -4,7 +4,7 @@ import Constants
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
-import androidx.room.RoomDatabase
+import androidx.room3.RoomDatabase
 import de.dbauer.expensetracker.shared.model.database.RecurringExpenseDatabase
 import de.dbauer.expensetracker.shared.model.database.getDatabaseBuilder
 import de.dbauer.expensetracker.shared.model.datastore.IUserPreferencesRepository

--- a/shared/src/iosMain/kotlin/de/dbauer/expensetracker/shared/model/database/GetDatabaseBuilder.kt
+++ b/shared/src/iosMain/kotlin/de/dbauer/expensetracker/shared/model/database/GetDatabaseBuilder.kt
@@ -1,8 +1,8 @@
 package de.dbauer.expensetracker.shared.model.database
 
 import Constants
-import androidx.room.Room
-import androidx.room.RoomDatabase
+import androidx.room3.Room
+import androidx.room3.RoomDatabase
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.Foundation.NSDocumentDirectory

--- a/shared/src/jvmMain/kotlin/de/dbauer/expensetracker/shared/di/Module.desktop.kt
+++ b/shared/src/jvmMain/kotlin/de/dbauer/expensetracker/shared/di/Module.desktop.kt
@@ -4,7 +4,7 @@ import Constants
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
-import androidx.room.RoomDatabase
+import androidx.room3.RoomDatabase
 import de.dbauer.expensetracker.shared.model.database.RecurringExpenseDatabase
 import de.dbauer.expensetracker.shared.model.database.getDatabaseBuilder
 import de.dbauer.expensetracker.shared.model.datastore.IUserPreferencesRepository

--- a/shared/src/jvmMain/kotlin/de/dbauer/expensetracker/shared/model/database/GetDatabaseBuilder.kt
+++ b/shared/src/jvmMain/kotlin/de/dbauer/expensetracker/shared/model/database/GetDatabaseBuilder.kt
@@ -1,8 +1,8 @@
 package de.dbauer.expensetracker.shared.model.database
 
 import Constants
-import androidx.room.Room
-import androidx.room.RoomDatabase
+import androidx.room3.Room
+import androidx.room3.RoomDatabase
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import java.io.File
 

--- a/shared/src/jvmTest/kotlin/de/dbauer/expensetracker/shared/model/database/RecurringExpenseDatabaseMigrationTest.kt
+++ b/shared/src/jvmTest/kotlin/de/dbauer/expensetracker/shared/model/database/RecurringExpenseDatabaseMigrationTest.kt
@@ -1,0 +1,66 @@
+package de.dbauer.expensetracker.shared.model.database
+
+import androidx.room3.Room
+import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import androidx.sqlite.execSQL
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RecurringExpenseDatabaseMigrationTest {
+    @Test
+    fun openingVersion2DatabaseRunsAllMigrations() =
+        runTest {
+            val dbFile = File.createTempFile("migration-test", ".db").apply { delete() }
+
+            // Create a database as Room 2 would have left it at schema version 2.
+            val connection = BundledSQLiteDriver().open(dbFile.absolutePath)
+            try {
+                connection.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `recurring_expenses` (`id` INTEGER PRIMARY KEY AUTOINCREMENT " +
+                        "NOT NULL, `name` TEXT, `description` TEXT, `price` REAL, `everyXRecurrence` INTEGER, " +
+                        "`recurrence` INTEGER)",
+                )
+                connection.execSQL(
+                    "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+                )
+                connection.execSQL(
+                    "INSERT OR REPLACE INTO room_master_table (id,identity_hash) " +
+                        "VALUES(42, '4f934843c2afcb230319f21e407a1b5f')",
+                )
+                connection.execSQL(
+                    "INSERT INTO `recurring_expenses` (`name`, `description`, `price`, `everyXRecurrence`, " +
+                        "`recurrence`) VALUES ('Netflix', 'Family plan', 9.99, 1, 3)",
+                )
+                connection.execSQL("PRAGMA user_version = 2")
+            } finally {
+                connection.close()
+            }
+
+            val database =
+                RecurringExpenseDatabase.getRecurringExpenseDatabase(
+                    Room
+                        .databaseBuilder<RecurringExpenseDatabase>(name = dbFile.absolutePath)
+                        .setDriver(BundledSQLiteDriver()),
+                )
+            try {
+                val expenses = database.recurringExpenseDao().getAllExpenses().first()
+                assertEquals(1, expenses.size)
+                assertEquals("Netflix", expenses.single().expense.name)
+                // Migration 3->4 backfills color = 0, which migration 5->6 converts into a tag.
+                assertEquals(
+                    "Untitled",
+                    expenses
+                        .single()
+                        .tags
+                        .single()
+                        .title,
+                )
+            } finally {
+                database.close()
+                dbFile.delete()
+            }
+        }
+}


### PR DESCRIPTION
New androidx.room3 coordinates and gradle plugin. Migrations now suspend, @Relation/@Junction columns plural, Android needs explicit driver (AndroidSQLiteDriver keeps framework SQLite). Schema identity hash unchanged so existing installs open cleanly; add jvm test covering full v2->v11 migration chain.